### PR TITLE
Src fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,3 +11,4 @@
 04-22-2019 - Add new reactive modes (wide, cross, nexus) for RGB Matrix  
 04-22-2019 - OLED Driver Features  
 04-22-2019 - Add Split RGB support  
+04-24-2019 - fix LIB_SRC and QUANTUM_LIB_SRC for ARM  

--- a/tmk_core/arm_atsam.mk
+++ b/tmk_core/arm_atsam.mk
@@ -6,7 +6,7 @@ CC = arm-none-eabi-gcc
 OBJCOPY = arm-none-eabi-objcopy
 OBJDUMP = arm-none-eabi-objdump
 SIZE = arm-none-eabi-size
-AR = arm-none-eabi-ar rcs
+AR = arm-none-eabi-ar
 NM = arm-none-eabi-nm
 HEX = $(OBJCOPY) -O $(FORMAT) -R .eeprom -R .fuse -R .lock -R .signature
 EEP = $(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" --change-section-lma .eeprom=0 --no-change-warnings -O $(FORMAT)

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -6,7 +6,7 @@ CC = avr-gcc
 OBJCOPY = avr-objcopy
 OBJDUMP = avr-objdump
 SIZE = avr-size
-AR = avr-ar rcs
+AR = avr-ar
 NM = avr-nm
 HEX = $(OBJCOPY) -O $(FORMAT) -R .eeprom -R .fuse -R .lock -R .signature
 EEP = $(OBJCOPY) -j .eeprom --set-section-flags=.eeprom="alloc,load" --change-section-lma .eeprom=0 --no-change-warnings -O $(FORMAT)

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -331,7 +331,7 @@ $1/%.o : %.S $1/asflags.txt $1/compiler.txt | $(BEGIN)
 $1/%.a : $1/%.o
 	@mkdir -p $$(@D)
 	@$(SILENT) || printf "Archiving: $$<" | $$(AWK_CMD)
-	$$(eval CMD=$$(AR) $$@ $$<)
+	$$(eval CMD=$$(AR) rcs $$@ $$<)
 	@$$(BUILD_CMD)
 
 $1/force:


### PR DESCRIPTION
This fixes the `LIB_SRC` and `QUANTUM_LIB_SRC` directives(?) for ARM.

These are used for including the same file multiple times, and to only include the compiled data when they're needed.  