### PR TITLE
Fix wakeup function on ChibiOS

### DIFF
--- a/tmk_core/common/chibios/suspend.c
+++ b/tmk_core/common/chibios/suspend.c
@@ -82,7 +82,7 @@ void suspend_wakeup_init_user(void) { }
  */
 __attribute__ ((weak))
 void suspend_wakeup_init_kb(void) {
-  suspend_power_down_user();
+  suspend_wakeup_init_user();
 }
 
 /** \brief suspend wakeup condition


### PR DESCRIPTION
The wake function was calling the sleep function.... whoops. 

This corrects that so that the wake function is properly called.