### PR TITLE
RGB Matrix: Custom effects on a kb/user level

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -178,6 +178,14 @@ ifeq ($(strip $(RGB_MATRIX_ENABLE)), WS2812)
     SRC += ws2812.c
 endif
 
+ifeq ($(strip $(RGB_MATRIX_CUSTOM_KB)), yes)
+    OPT_DEFS += -DRGB_MATRIX_CUSTOM_KB
+endif
+
+ifeq ($(strip $(RGB_MATRIX_CUSTOM_USER)), yes)
+    OPT_DEFS += -DRGB_MATRIX_CUSTOM_USER
+endif
+
 ifeq ($(strip $(TAP_DANCE_ENABLE)), yes)
     OPT_DEFS += -DTAP_DANCE_ENABLE
     SRC += $(QUANTUM_DIR)/process_keycode/process_tap_dance.c

--- a/quantum/rgb_matrix.h
+++ b/quantum/rgb_matrix.h
@@ -142,6 +142,18 @@ enum rgb_matrix_effects {
   RGB_MATRIX_SOLID_MULTISPLASH,
 #endif // DISABLE_RGB_MATRIX_SOLID_MULTISPLASH
 #endif // RGB_MATRIX_KEYREACTIVE_ENABLED
+
+#if defined(RGB_MATRIX_CUSTOM_KB) || defined(RGB_MATRIX_CUSTOM_USER)
+  #define RGB_MATRIX_EFFECT(name, ...) RGB_MATRIX_CUSTOM_##name,
+  #ifdef RGB_MATRIX_CUSTOM_KB
+    #include "rgb_matrix_kb.inc"
+  #endif
+  #ifdef RGB_MATRIX_CUSTOM_USER
+    #include "rgb_matrix_user.inc"
+  #endif
+  #undef RGB_MATRIX_EFFECT
+#endif
+
   RGB_MATRIX_EFFECT_MAX
 };
 


### PR DESCRIPTION
I'm not sure we actually need this.... but ... it could be a good alternate way to handle the LED maps for the Glow keyboards.  

Otherwise, this is to keep in lockstep with upstream. 