### PR TITLE
Fixing incorrect usage of RGBLED_NUM in ws2812 driver when used with RGB Matrix (#5744)

### DIFF
--- a/drivers/avr/ws2812.c
+++ b/drivers/avr/ws2812.c
@@ -158,7 +158,7 @@ void inline ws2812_setled(int i, uint8_t r, uint8_t g, uint8_t b)
 
 void ws2812_setled_all  (uint8_t r, uint8_t g, uint8_t b)
 {
-  for (int i = 0; i < RGBLED_NUM; i++) {
+  for (int i = 0; i < sizeof(led)/sizeof(led[0]); i++) {
     led[i].r = r;
     led[i].g = g;
     led[i].b = b;

--- a/quantum/rgb_matrix_drivers.c
+++ b/quantum/rgb_matrix_drivers.c
@@ -99,12 +99,12 @@ const rgb_matrix_driver_t rgb_matrix_driver = {
 
 #elif defined(WS2812)
 
-extern LED_TYPE led[RGBLED_NUM];
+extern LED_TYPE led[DRIVER_LED_TOTAL];
 
   static void flush( void )
   {
     // Assumes use of RGB_DI_PIN
-    ws2812_setleds(led, RGBLED_NUM);
+    ws2812_setleds(led, DRIVER_LED_TOTAL);
   }
 
   static void init( void )


### PR DESCRIPTION
THis isn't strictly necessary, since we don't use this...

But this is to keep in lockstep with upstream. Especially if we do choose to use it in the future. 