### PR TITLE
Fix LIB_SRC insert position (#5731)

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -324,7 +324,6 @@ ifneq ("$(wildcard $(KEYMAP_PATH)/config.h)","")
 endif
 
 # # project specific files
-SRC += $(patsubst %.c,%.clib,$(LIB_SRC))
 SRC += $(KEYBOARD_SRC) \
     $(KEYMAP_C) \
     $(QUANTUM_SRC)
@@ -343,6 +342,7 @@ include $(TMK_PATH)/protocol.mk
 include $(TMK_PATH)/common.mk
 include bootloader.mk
 
+SRC += $(patsubst %.c,%.clib,$(LIB_SRC))
 SRC += $(patsubst %.c,%.clib,$(QUANTUM_LIB_SRC))
 SRC += $(TMK_COMMON_SRC)
 OPT_DEFS += $(TMK_COMMON_DEFS)


### PR DESCRIPTION
The insertion point for `$(patsubst %.c,%.clib,$(LIB_SRC))` must be after all normal `SRC += ..` . I modified it to be so.

Because LIB_SRC and SRC are assumed to be used in pairs. Similarly, QUANTUM_LIB_SRC and QUANTUM_SRC are assumed to be used in pairs.


The use case for this is adding files multiple times, without errors.  Eg, adding i2c_master.c twice, for the Ergodox EZ Glow (both the expander and rgb matrix call the file)