### PR TITLE
Add DFU Suffix for ARM boards (#5763)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,14 @@ env:
   - MAKEFLAGS="-j3 --output-sync"
 before_install:
   - wget http://ww1.microchip.com/downloads/en/DeviceDoc/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz || wget http://qmk.fm/avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
+  # Need DFU > .5 for dfu-suffix
+  - sudo add-apt-repository --yes ppa:tormodvolden/ppa
+  - sudo apt-get update -qq
 install:
   - tar -zxf avr8-gnu-toolchain-3.5.4.1709-linux.any.x86_64.tar.gz
   - export PATH="$PATH:$TRAVIS_BUILD_DIR/avr8-gnu-toolchain-linux_x86_64/bin"
   - npm install -g moxygen
+  - sudo apt-get -y --force-yes install dfu-util
 before_script:
   - avr-gcc --version
 script:

--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -34,6 +34,7 @@ ifneq ($(findstring STM32F303, $(MCU)),)
 
   # Options to pass to dfu-util when flashing
   DFU_ARGS ?= -d 0483:df11 -a 0 -s 0x08000000:leave
+  DFU_SUFFIX_ARGS = -p DF11 -v 0483
 endif
 
 ifneq (,$(filter $(MCU),atmega32u4 at90usb1286))

--- a/quantum/stm32/proton_c.mk
+++ b/quantum/stm32/proton_c.mk
@@ -42,3 +42,4 @@ OPT_DEFS =
 
 # Options to pass to dfu-util when flashing
 DFU_ARGS = -d 0483:df11 -a 0 -s 0x08000000:leave
+DFU_SUFFIX_ARGS = -p df11 -v 0483

--- a/tmk_core/chibios.mk
+++ b/tmk_core/chibios.mk
@@ -201,6 +201,7 @@ DFU_ARGS ?=
 ifneq ("$(SERIAL)","")
 	DFU_ARGS += -S $(SERIAL)
 endif
+DFU_SUFFIX_ARGS ?=
 
 ST_LINK_ARGS ?=
 
@@ -208,6 +209,7 @@ ST_LINK_ARGS ?=
 EXTRALIBDIRS = $(RULESPATH)/ld
 
 DFU_UTIL ?= dfu-util
+DFU_SUFFIX ?= dfu-suffix
 ST_LINK_CLI ?= st-link_cli
 
 # Generate a .qmk for the QMK-FF
@@ -259,4 +261,7 @@ st-link-cli: $(BUILD_DIR)/$(TARGET).hex sizeafter
 	$(ST_LINK_CLI) $(ST_LINK_ARGS) -q -c SWD -p $(BUILD_DIR)/$(TARGET).hex -Rst
 
 bin: $(BUILD_DIR)/$(TARGET).bin sizeafter
+	if [ ! -z "$(DFU_SUFFIX_ARGS)" ]; then \
+		$(DFU_SUFFIX) $(DFU_SUFFIX_ARGS) -a $(BUILD_DIR)/$(TARGET).bin 1>/dev/null ;\
+	fi
 	$(COPY) $(BUILD_DIR)/$(TARGET).bin $(TARGET).bin;


### PR DESCRIPTION
This adds the DFU Suffix, based on setting set in the makefile.

I've tested this on the Planck EZ and have confirmed that it works.

However, wally may/will need to be updated to not flash the suffix part (since it's not supposed to)