### PR TITLE
Added check for event pressed to clear space cadet (qmk#5839)

### DIFF
--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -81,11 +81,17 @@
 
 static uint8_t sc_last = 0;
 static uint16_t sc_timer = 0;
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+static uint8_t sc_mods = 0;
+#endif
 
 void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, uint8_t keycode) {
   if (record->event.pressed) {
     sc_last = holdMod;
     sc_timer = timer_read ();
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+    sc_mods = get_mods();
+#endif
     if (IS_MOD(holdMod)) {
       register_mods(MOD_BIT(holdMod));
     }
@@ -100,7 +106,13 @@ void perform_space_cadet(keyrecord_t *record, uint8_t holdMod, uint8_t tapMod, u
           register_mods(MOD_BIT(tapMod));
         }
       }
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+    set_weak_mods(sc_mods);
+#endif
       tap_code(keycode);
+#ifdef SPACE_CADET_MODIFIER_CARRYOVER
+    clear_weak_mods();
+#endif
       if (IS_MOD(tapMod)) {
         unregister_mods(MOD_BIT(tapMod));
       }

--- a/quantum/process_keycode/process_space_cadet.c
+++ b/quantum/process_keycode/process_space_cadet.c
@@ -60,18 +60,18 @@
 
 // Control / paren setup
 #ifndef LCPO_KEYS
-  #define LCPO_KEYS KC_LCTL, KC_LCTL, KC_9
+  #define LCPO_KEYS KC_LCTL, KC_LSFT, KC_9
 #endif
 #ifndef RCPC_KEYS
-  #define RCPC_KEYS KC_RCTL, KC_RCTL, KC_0
+  #define RCPC_KEYS KC_RCTL, KC_RSFT, KC_0
 #endif
 
 // Alt / paren setup
 #ifndef LAPO_KEYS
-  #define LAPO_KEYS KC_LALT, KC_LALT, KC_9
+  #define LAPO_KEYS KC_LALT, KC_LSFT, KC_9
 #endif
 #ifndef RAPC_KEYS
-  #define RAPC_KEYS KC_RALT, KC_RALT, KC_0
+  #define RAPC_KEYS KC_RALT, KC_RSFT, KC_0
 #endif
 
 // Shift / Enter setup
@@ -143,7 +143,9 @@ bool process_space_cadet(uint16_t keycode, keyrecord_t *record) {
       return false;
     }
     default: {
-      sc_last = 0;
+      if (record->event.pressed) {
+        sc_last = 0;
+      }
       break;
     }
   }


### PR DESCRIPTION
Fixes default behavior to be correct. 

Also, fixes an issue that comes up when typing fast:
```
When typing fast, you could press down A, then press LSPO, releasing A, then releasing LSPO. The releasing of A would cause space cadet to be cleared and not trigger when in reality it should still trigger in this case.
```
