### PR TITLE
Typedef'ed layer_state_t to uint32_t (qmk#3637)

### DIFF
--- a/keyboards/ergodox_ez/keymaps/default/keymap.c
+++ b/keyboards/ergodox_ez/keymaps/default/keymap.c
@@ -164,7 +164,7 @@ void matrix_init_user(void) {
 };
 
 // Runs whenever there is a layer state change.
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   ergodox_board_led_off();
   ergodox_right_led_1_off();
   ergodox_right_led_2_off();

--- a/keyboards/planck/ez/ez.c
+++ b/keyboards/planck/ez/ez.c
@@ -117,7 +117,7 @@ void matrix_scan_kb(void) {
   matrix_scan_user();
 }
 
-uint32_t layer_state_set_kb(uint32_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
 
   palClearPad(GPIOB, 8);
   palClearPad(GPIOB, 9);

--- a/keyboards/planck/keymaps/default/keymap.c
+++ b/keyboards/planck/keymaps/default/keymap.c
@@ -176,7 +176,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   float plover_gb_song[][2]  = SONG(PLOVER_GOODBYE_SOUND);
 #endif
 
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return update_tri_layer_state(state, _LOWER, _RAISE, _ADJUST);
 }
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -861,9 +861,9 @@ void set_single_persistent_default_layer(uint8_t default_layer) {
   default_layer_set(1U<<default_layer);
 }
 
-uint32_t update_tri_layer_state(uint32_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
-  uint32_t mask12 = (1UL << layer1) | (1UL << layer2);
-  uint32_t mask3 = 1UL << layer3;
+layer_state_t  update_tri_layer_state(layer_state_t  state, uint8_t layer1, uint8_t layer2, uint8_t layer3) {
+  layer_state_t  mask12 = (1UL << layer1) | (1UL << layer2);
+  layer_state_t  mask3 = 1UL << layer3;
   return (state & mask12) == mask12 ? (state | mask3) : (state & ~mask3);
 }
 

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -61,10 +61,10 @@
 #include "send_string_keycodes.h"
 #include "suspend.h"
 
-extern uint32_t default_layer_state;
+extern layer_state_t default_layer_state;
 
 #ifndef NO_ACTION_LAYER
-    extern uint32_t layer_state;
+    extern layer_state_t layer_state;
 #endif
 
 #ifdef MIDI_ENABLE

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -224,7 +224,7 @@ void send_char(char ascii_code);
 
 // For tri-layer
 void update_tri_layer(uint8_t layer1, uint8_t layer2, uint8_t layer3);
-uint32_t update_tri_layer_state(uint32_t state, uint8_t layer1, uint8_t layer2, uint8_t layer3);
+layer_state_t  update_tri_layer_state(layer_state_t  state, uint8_t layer1, uint8_t layer2, uint8_t layer3);
 
 void set_single_persistent_default_layer(uint8_t default_layer);
 

--- a/quantum/visualizer/visualizer.c
+++ b/quantum/visualizer/visualizer.c
@@ -437,7 +437,7 @@ uint8_t visualizer_get_mods() {
   if (!has_oneshot_mods_timed_out()) {
     mods |= get_oneshot_mods();
   }
-#endif  
+#endif
   return mods;
 }
 
@@ -447,7 +447,7 @@ void visualizer_set_user_data(void* u) {
 }
 #endif
 
-void visualizer_update(uint32_t default_state, uint32_t state, uint8_t mods, uint32_t leds) {
+void visualizer_update(layer_state_t default_state, layer_state_t state, uint8_t mods, uint32_t leds) {
     // Note that there's a small race condition here, the thread could read
     // a state where one of these are set but not the other. But this should
     // not really matter as it will be fixed during the next loop step.

--- a/quantum/visualizer/visualizer.h
+++ b/quantum/visualizer/visualizer.h
@@ -45,7 +45,7 @@ uint8_t visualizer_get_mods(void);
 // This need to be called once at the start
 void visualizer_init(void);
 // This should be called at every matrix scan
-void visualizer_update(uint32_t default_state, uint32_t state, uint8_t mods, uint32_t leds);
+void visualizer_update(layer_state_t default_state, layer_state_t state, uint8_t mods, uint32_t leds);
 
 // This should be called when the keyboard goes to suspend state
 void visualizer_suspend(void);
@@ -68,8 +68,8 @@ void draw_emulator(void);
 struct keyframe_animation_t;
 
 typedef struct {
-    uint32_t layer;
-    uint32_t default_layer;
+    layer_state_t layer;
+    layer_state_t default_layer;
     uint32_t leds; // See led.h for available statuses
     uint8_t mods;
     bool suspended;

--- a/quantum/visualizer/visualizer.h
+++ b/quantum/visualizer/visualizer.h
@@ -30,6 +30,7 @@ SOFTWARE.
 
 #include "config.h"
 #include "gfx.h"
+#include "action_layer.h"
 
 #ifdef LCD_BACKLIGHT_ENABLE
 #include "lcd_backlight.h"

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -406,8 +406,8 @@ void process_action(keyrecord_t *record, action_t action)
                 /* Default Layer Bitwise Operation */
                 if (!event.pressed) {
                     uint8_t shift = action.layer_bitop.part*4;
-                    uint32_t bits = ((uint32_t)action.layer_bitop.bits)<<shift;
-                    uint32_t mask = (action.layer_bitop.xbit) ? ~(((uint32_t)0xf)<<shift) : 0;
+                    layer_state_t bits = ((layer_state_t)action.layer_bitop.bits)<<shift;
+                    layer_state_t mask = (action.layer_bitop.xbit) ? ~(((layer_state_t)0xf)<<shift) : 0;
                     switch (action.layer_bitop.op) {
                         case OP_BIT_AND: default_layer_and(bits | mask); break;
                         case OP_BIT_OR:  default_layer_or(bits | mask);  break;
@@ -420,8 +420,8 @@ void process_action(keyrecord_t *record, action_t action)
                 if (event.pressed ? (action.layer_bitop.on & ON_PRESS) :
                                     (action.layer_bitop.on & ON_RELEASE)) {
                     uint8_t shift = action.layer_bitop.part*4;
-                    uint32_t bits = ((uint32_t)action.layer_bitop.bits)<<shift;
-                    uint32_t mask = (action.layer_bitop.xbit) ? ~(((uint32_t)0xf)<<shift) : 0;
+                    layer_state_t bits = ((layer_state_t)action.layer_bitop.bits)<<shift;
+                    layer_state_t mask = (action.layer_bitop.xbit) ? ~(((layer_state_t)0xf)<<shift) : 0;
                     switch (action.layer_bitop.op) {
                         case OP_BIT_AND: layer_and(bits | mask); break;
                         case OP_BIT_OR:  layer_or(bits | mask);  break;

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -13,14 +13,14 @@
 
 /** \brief Default Layer State
  */
-uint32_t default_layer_state = 0;
+layer_state_t default_layer_state = 0;
 
 /** \brief Default Layer State Set At user Level
  *
  * Run user code on default layer state change
  */
 __attribute__((weak))
-uint32_t default_layer_state_set_user(uint32_t state) {
+layer_state_t default_layer_state_set_user(layer_state_t state) {
   return state;
 }
 
@@ -29,7 +29,7 @@ uint32_t default_layer_state_set_user(uint32_t state) {
  *  Run keyboard code on default layer state change
  */
 __attribute__((weak))
-uint32_t default_layer_state_set_kb(uint32_t state) {
+layer_state_t default_layer_state_set_kb(layer_state_t state) {
   return default_layer_state_set_user(state);
 }
 
@@ -37,7 +37,7 @@ uint32_t default_layer_state_set_kb(uint32_t state) {
  *
  * Static function to set the default layer state, prints debug info and clears keys
  */
-static void default_layer_state_set(uint32_t state) {
+static void default_layer_state_set(layer_state_t state) {
   state = default_layer_state_set_kb(state);
   debug("default_layer_state: ");
   default_layer_debug(); debug(" to ");
@@ -62,7 +62,7 @@ void default_layer_debug(void) {
  *
  * Sets the default layer state.
  */
-void default_layer_set(uint32_t state) {
+void default_layer_set(layer_state_t state) {
   default_layer_state_set(state);
 }
 
@@ -71,21 +71,21 @@ void default_layer_set(uint32_t state) {
  *
  * Turns on the default layer based on matching bits between specifed layer and existing layer state
  */
-void default_layer_or(uint32_t state) {
+void default_layer_or(layer_state_t state) {
   default_layer_state_set(default_layer_state | state);
 }
 /** \brief Default Layer And
  *
  * Turns on default layer based on matching enabled bits between specifed layer and existing layer state
  */
-void default_layer_and(uint32_t state) {
+void default_layer_and(layer_state_t state) {
   default_layer_state_set(default_layer_state & state);
 }
 /** \brief Default Layer Xor
  *
  * Turns on default layer based on non-matching bits between specifed layer and existing layer state
  */
-void default_layer_xor(uint32_t state) {
+void default_layer_xor(layer_state_t state) {
   default_layer_state_set(default_layer_state ^ state);
 }
 #endif
@@ -94,14 +94,14 @@ void default_layer_xor(uint32_t state) {
 #ifndef NO_ACTION_LAYER
 /** \brief Keymap Layer State
  */
-uint32_t layer_state = 0;
+layer_state_t layer_state = 0;
 
 /** \brief Layer state set user
  *
  * Runs user code on layer state change
  */
 __attribute__((weak))
-uint32_t layer_state_set_user(uint32_t state) {
+layer_state_t layer_state_set_user(layer_state_t state) {
   return state;
 }
 
@@ -110,7 +110,7 @@ uint32_t layer_state_set_user(uint32_t state) {
  * Runs keyboard code on layer state change
  */
 __attribute__((weak))
-uint32_t layer_state_set_kb(uint32_t state) {
+layer_state_t layer_state_set_kb(layer_state_t state) {
   return layer_state_set_user(state);
 }
 
@@ -118,7 +118,7 @@ uint32_t layer_state_set_kb(uint32_t state) {
  *
  * Sets the layer to match the specifed state (a bitmask)
  */
-void layer_state_set(uint32_t state) {
+void layer_state_set(layer_state_t state) {
   state = layer_state_set_kb(state);
   dprint("layer_state: ");
   layer_debug(); dprint(" to ");
@@ -151,7 +151,7 @@ bool layer_state_is(uint8_t layer) {
  *
  * Used for comparing layers {mostly used for unit testing}
  */
-bool layer_state_cmp(uint32_t cmp_layer_state, uint8_t layer) {
+bool layer_state_cmp(layer_state_t cmp_layer_state, uint8_t layer) {
   if (!cmp_layer_state) { return layer == 0; }
   return (cmp_layer_state & (1UL<<layer)) != 0;
 }
@@ -192,21 +192,21 @@ void layer_invert(uint8_t layer) {
  *
  * Turns on layers based on matching bits between specifed layer and existing layer state
  */
-void layer_or(uint32_t state) {
+void layer_or(layer_state_t state) {
   layer_state_set(layer_state | state);
 }
 /** \brief Layer and
  *
  * Turns on layers based on matching enabled bits between specifed layer and existing layer state
  */
-void layer_and(uint32_t state) {
+void layer_and(layer_state_t state) {
   layer_state_set(layer_state & state);
 }
 /** \brief Layer xor
  *
  * Turns on layers based on non-matching bits between specifed layer and existing layer state
  */
-void layer_xor(uint32_t state) {
+void layer_xor(layer_state_t state) {
   layer_state_set(layer_state ^ state);
 }
 
@@ -301,9 +301,9 @@ uint8_t layer_switch_get_layer(keypos_t key) {
   action_t action;
   action.code = ACTION_TRANSPARENT;
 
-  uint32_t layers = layer_state | default_layer_state;
+  layer_state_t layers = layer_state | default_layer_state;
   /* check top layer first */
-  for (int8_t i = 31; i >= 0; i--) {
+  for (int8_t i = sizeof(layer_state_t)-1; i >= 0; i--) {
     if (layers & (1UL << i)) {
       action = action_for_key(i, key);
       if (action.code != ACTION_TRANSPARENT) {

--- a/tmk_core/common/action_layer.c
+++ b/tmk_core/common/action_layer.c
@@ -303,7 +303,7 @@ uint8_t layer_switch_get_layer(keypos_t key) {
 
   layer_state_t layers = layer_state | default_layer_state;
   /* check top layer first */
-  for (int8_t i = sizeof(layer_state_t)-1; i >= 0; i--) {
+  for (int8_t i = sizeof(layer_state_t) * 8 - 1; i >= 0; i--) {
     if (layers & (1UL << i)) {
       action = action_for_key(i, key);
       if (action.code != ACTION_TRANSPARENT) {

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -21,24 +21,32 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keyboard.h"
 #include "action.h"
 
+#if defined(LAYER_STATE_8BIT) || ( defined(DYNAMIC_KEYMAP_ENABLE) && DYNAMIC_KEYMAP_LAYER_COUNT >= 8 )
+typedef uint8_t layer_state_t;
+#elif defined(LAYER_STATE_16BIT)
+typedef uint16_t layer_state_t;
+#else
+typedef uint32_t layer_state_t;
+#endif
+
 
 /*
  * Default Layer
  */
-extern uint32_t default_layer_state;
+extern layer_state_t default_layer_state;
 void default_layer_debug(void);
-void default_layer_set(uint32_t state);
+void default_layer_set(layer_state_t state);
 
 __attribute__((weak))
-uint32_t default_layer_state_set_kb(uint32_t state);
+layer_state_t default_layer_state_set_kb(layer_state_t state);
 __attribute__((weak))
-uint32_t default_layer_state_set_user(uint32_t state);
+layer_state_t default_layer_state_set_user(layer_state_t state);
 
 #ifndef NO_ACTION_LAYER
 /* bitwise operation */
-void default_layer_or(uint32_t state);
-void default_layer_and(uint32_t state);
-void default_layer_xor(uint32_t state);
+void default_layer_or(layer_state_t state);
+void default_layer_and(layer_state_t state);
+void default_layer_xor(layer_state_t state);
 #else
 #define default_layer_or(state)
 #define default_layer_and(state)
@@ -50,11 +58,11 @@ void default_layer_xor(uint32_t state);
  * Keymap Layer
  */
 #ifndef NO_ACTION_LAYER
-extern uint32_t layer_state;
+extern layer_state_t layer_state;
 
-void layer_state_set(uint32_t state);
+void layer_state_set(layer_state_t state);
 bool layer_state_is(uint8_t layer);
-bool layer_state_cmp(uint32_t layer1, uint8_t layer2);
+bool layer_state_cmp(layer_state_t layer1, uint8_t layer2);
 
 void layer_debug(void);
 void layer_clear(void);
@@ -63,9 +71,9 @@ void layer_on(uint8_t layer);
 void layer_off(uint8_t layer);
 void layer_invert(uint8_t layer);
 /* bitwise operation */
-void layer_or(uint32_t state);
-void layer_and(uint32_t state);
-void layer_xor(uint32_t state);
+void layer_or(layer_state_t state);
+void layer_and(layer_state_t state);
+void layer_xor(layer_state_t state);
 #else
 #define layer_state                    0
 
@@ -84,8 +92,8 @@ void layer_xor(uint32_t state);
 #define layer_xor(state)
 #endif
 
-uint32_t layer_state_set_user(uint32_t state);
-uint32_t layer_state_set_kb(uint32_t state);
+layer_state_t layer_state_set_user(layer_state_t state);
+layer_state_t layer_state_set_kb(layer_state_t state);
 
 /* pressed actions cache */
 #if !defined(NO_ACTION_LAYER) && !defined(STRICT_LAYER_RELEASE)

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -21,7 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "keyboard.h"
 #include "action.h"
 
-#if defined(LAYER_STATE_8BIT) || ( defined(DYNAMIC_KEYMAP_ENABLE) && DYNAMIC_KEYMAP_LAYER_COUNT >= 8 )
+#if defined(LAYER_STATE_8BIT)
 typedef uint8_t layer_state_t;
 #define get_highest_layer(state) biton8(state)
 #elif defined(LAYER_STATE_16BIT)

--- a/tmk_core/common/action_layer.h
+++ b/tmk_core/common/action_layer.h
@@ -23,10 +23,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #if defined(LAYER_STATE_8BIT) || ( defined(DYNAMIC_KEYMAP_ENABLE) && DYNAMIC_KEYMAP_LAYER_COUNT >= 8 )
 typedef uint8_t layer_state_t;
+#define get_highest_layer(state) biton8(state)
 #elif defined(LAYER_STATE_16BIT)
 typedef uint16_t layer_state_t;
+#define get_highest_layer(state) biton16(state)
 #else
 typedef uint32_t layer_state_t;
+#define get_highest_layer(state) biton32(state)
 #endif
 
 

--- a/tmk_core/common/bootmagic.c
+++ b/tmk_core/common/bootmagic.c
@@ -99,10 +99,10 @@ void bootmagic(void)
     if (bootmagic_scan_keycode(BOOTMAGIC_KEY_DEFAULT_LAYER_7)) { default_layer |= (1<<7); }
     if (default_layer) {
         eeconfig_update_default_layer(default_layer);
-        default_layer_set((uint32_t)default_layer);
+        default_layer_set((layer_state_t)default_layer);
     } else {
         default_layer = eeconfig_read_default_layer();
-        default_layer_set((uint32_t)default_layer);
+        default_layer_set((layer_state_t)default_layer);
     }
 }
 

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -8,7 +8,7 @@
 #include "eeprom_stm32.h"
 #endif
 
-extern uint32_t default_layer_state;
+extern uint32_t  default_layer_state;
 /** \brief eeconfig enable
  *
  * FIXME: needs doc

--- a/tmk_core/common/magic.c
+++ b/tmk_core/common/magic.c
@@ -33,6 +33,6 @@ void magic(void)
 
     uint8_t default_layer = 0;
     default_layer = eeconfig_read_default_layer();
-    default_layer_set((uint32_t)default_layer);
+    default_layer_set((layer_state_t)default_layer);
 
 }


### PR DESCRIPTION
This changes the uint32_t type for the layer state variable to a typedef'd one. 

This may allow for some optimization in certain cases. 

Specifically, to change the typedef:
```
#if defined(LAYER_STATE_8BIT) || ( defined(DYNAMIC_KEYMAP_ENABLE) && DYNAMIC_KEYMAP_LAYER_COUNT >= 8 )
typedef uint8_t layer_state_t;
#elif defined(LAYER_STATE_16BIT)
typedef uint16_t layer_state_t;
#else
typedef uint32_t layer_state_t;
#endif
```

So, you'd want to add `#define LAYER_STATE_8BIT` to change it to an 8 bit mask (limit 8 layers)


That said, I have a follow-up PR to make this more complete.