### PR TITLE
Fix up Debouncing in AVR Templates 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,3 +22,4 @@
 05-06-2019 - More readable fix of Mousekeys issue  
 05-06-2019 - Changes to Split Common and OLED code  
 05-16-2019 - Add RGB Light Effect Range functionality   
+05-26-2019 - Update templates to use proper debounce define

--- a/quantum/template/avr/config.h
+++ b/quantum/template/avr/config.h
@@ -86,7 +86,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // #endif
 
 /* Debounce reduces chatter (unintended double-presses) - set 0 if debouncing is not needed */
-#define DEBOUNCING_DELAY 5
+#define DEBOUNCE 5
 
 /* define if matrix has ghost (lacks anti-ghosting diodes) */
 //#define MATRIX_HAS_GHOST

--- a/quantum/template/ps2avrgb/config.h
+++ b/quantum/template/ps2avrgb/config.h
@@ -34,7 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define UNUSED_PINS
 
 #define DIODE_DIRECTION COL2ROW
-#define DEBOUNCING_DELAY 5
+#define DEBOUNCE 5
 
 #define NO_BACKLIGHT_CLOCK
 #define BACKLIGHT_LEVELS 1


### PR DESCRIPTION
Updates the templates to use the correct define for debouncing timeout. 

Mostly to keep in lockstep with upstream.