### PR TITLE
Fix TO() and DF() calling layer_state_set_[kb,user] twice (qmk#6003)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,3 +22,4 @@
 05-06-2019 - More readable fix of Mousekeys issue  
 05-06-2019 - Changes to Split Common and OLED code  
 05-16-2019 - Add RGB Light Effect Range functionality   
+05-29-2019 - Fix TO() and DF() calling layer_state_set_[kb,user] twice (qmk#6003)

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -412,7 +412,7 @@ void process_action(keyrecord_t *record, action_t action)
                         case OP_BIT_AND: default_layer_and(bits | mask); break;
                         case OP_BIT_OR:  default_layer_or(bits | mask);  break;
                         case OP_BIT_XOR: default_layer_xor(bits | mask); break;
-                        case OP_BIT_SET: default_layer_and(mask); default_layer_or(bits); break;
+                        case OP_BIT_SET: default_layer_set(bits | mask); break;
                     }
                 }
             } else {
@@ -426,7 +426,7 @@ void process_action(keyrecord_t *record, action_t action)
                         case OP_BIT_AND: layer_and(bits | mask); break;
                         case OP_BIT_OR:  layer_or(bits | mask);  break;
                         case OP_BIT_XOR: layer_xor(bits | mask); break;
-                        case OP_BIT_SET: layer_and(mask); layer_or(bits); break;
+                        case OP_BIT_SET: layer_state_set(bits | mask); break;
                     }
                 }
             }


### PR DESCRIPTION
This changes a couple of the calls for action codes so that it only cause the layer state code once, rather than twice. 

