### PR TITLE
Fixing matrix_scan so it properly returns changed status

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,3 +22,4 @@
 05-06-2019 - More readable fix of Mousekeys issue  
 05-06-2019 - Changes to Split Common and OLED code  
 05-16-2019 - Add RGB Light Effect Range functionality   
+05-29-2019 - Fixing matrix_scan so it properly returns changed status

--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -326,5 +326,5 @@ uint8_t matrix_scan(void)
   debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
 
   matrix_scan_quantum();
-  return 1;
+  return (uint8_t)changed;
 }


### PR DESCRIPTION
Since there are stuff now that is looking for this ... and the split keyboards already do this.

Just reports if the matrix did actually change, or not, rather than always reporting `1`/true. 