### PR TITLE
Fixing matrix_scan so it properly returns changed status on Ergodox EZ

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -188,7 +188,7 @@ uint8_t matrix_scan(void) {
   debounce(raw_matrix, matrix, MATRIX_ROWS, changed);
   matrix_scan_quantum();
 
-  return 1;
+  return (uint8_t)changed;
 }
 
 bool matrix_is_modified(void)  // deprecated and evidently not called.


### PR DESCRIPTION
This way, the Ergodox EZ also reports the proper changed status, rather than always just `1`. 