### PR TITLE
Smallish overhaul of Auto-Shift feature

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,3 +25,4 @@
 05-26-2019 - Update templates to use proper debounce define  
 05-26-2019 - Add Solus support for Linux install script  
 05-29-2019 - Fix TO() and DF() calling layer_state_set_[kb,user] twice (qmk#6003)   
+06-03-2019 - Overhaul of AutoShift feature (qmk#6067)

--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -20,191 +20,132 @@
 
 #include "process_auto_shift.h"
 
-#define TAP(key) \
-  register_code(key); \
-  unregister_code(key)
-
-#define TAP_WITH_MOD(mod, key) \
-  register_code(mod); \
-  register_code(key); \
-  unregister_code(key); \
-  unregister_code(mod)
-
-uint16_t autoshift_time = 0;
-uint16_t autoshift_timeout = AUTO_SHIFT_TIMEOUT;
-uint16_t autoshift_lastkey = KC_NO;
+static bool autoshift_enabled = true;
+static uint16_t autoshift_time = 0;
+static uint16_t autoshift_timeout = AUTO_SHIFT_TIMEOUT;
+static uint16_t autoshift_lastkey = KC_NO;
 
 void autoshift_timer_report(void) {
-  char display[8];
+    char display[8];
 
-  snprintf(display, 8, "\n%d\n", autoshift_timeout);
+    snprintf(display, 8, "\n%d\n", autoshift_timeout);
 
-  send_string((const char *)display);
+    send_string((const char *)display);
 }
 
 void autoshift_on(uint16_t keycode) {
-  autoshift_time = timer_read();
-  autoshift_lastkey = keycode;
+    autoshift_time = timer_read();
+    autoshift_lastkey = keycode;
 }
 
 void autoshift_flush(void) {
-  if (autoshift_lastkey != KC_NO) {
-    uint16_t elapsed = timer_elapsed(autoshift_time);
+    if (autoshift_lastkey != KC_NO) {
+        uint16_t elapsed = timer_elapsed(autoshift_time);
 
-    if (elapsed > autoshift_timeout) {
-      register_code(KC_LSFT);
+        if (elapsed > autoshift_timeout) {
+            tap_code16(LSFT(autoshift_lastkey));
+        } else {
+            tap_code(autoshift_lastkey);
+        }
+
+        autoshift_time = 0;
+        autoshift_lastkey = KC_NO;
     }
-
-    register_code(autoshift_lastkey);
-    unregister_code(autoshift_lastkey);
-
-    if (elapsed > autoshift_timeout) {
-      unregister_code(KC_LSFT);
-    }
-
-    autoshift_time = 0;
-    autoshift_lastkey = KC_NO;
-  }
 }
 
-bool autoshift_enabled = true;
 
 void autoshift_enable(void) {
     autoshift_enabled = true;
 }
 void autoshift_disable(void) {
-  autoshift_enabled = false;
-  autoshift_flush();
+    autoshift_enabled = false;
+    autoshift_flush();
 }
 
 void autoshift_toggle(void) {
-  if (autoshift_enabled) {
-    autoshift_enabled = false;
-    autoshift_flush();
-  }
-  else {
-    autoshift_enabled = true;
-  }
+    if (autoshift_enabled) {
+        autoshift_enabled = false;
+        autoshift_flush();
+    }
+    else {
+        autoshift_enabled = true;
+    }
 }
 
-bool autoshift_state(void) {
+bool get_autoshift_state(void) {
   return autoshift_enabled;
 }
 
+uint16_t get_autoshift_timeout(void) {
+  return autoshift_timeout;
+}
+
+void set_autoshift_timeout(uint16_t timeout) {
+    autoshift_timeout = timeout;
+}
+
 bool process_auto_shift(uint16_t keycode, keyrecord_t *record) {
-#ifndef AUTO_SHIFT_MODIFIERS
-  static uint8_t any_mod_pressed;
-#endif
 
-  if (record->event.pressed) {
-    switch (keycode) {
-      case KC_ASUP:
-        autoshift_timeout += 5;
-        return false;
+    if (record->event.pressed) {
+        switch (keycode) {
+        case KC_ASUP:
+            autoshift_timeout += 5;
+            return true;
 
-      case KC_ASDN:
-        autoshift_timeout -= 5;
-        return false;
+        case KC_ASDN:
+            autoshift_timeout -= 5;
+            return true;
 
-      case KC_ASRP:
-        autoshift_timer_report();
-        return false;
+        case KC_ASRP:
+            autoshift_timer_report();
+            return true;
 
-      case KC_ASTG:
-        autoshift_toggle();
-        return false;
-      case KC_ASON:
-        autoshift_enable();
-        return false;
-      case KC_ASOFF:
-        autoshift_disable();
-        return false;
+        case KC_ASTG:
+            autoshift_toggle();
+            return true;
+        case KC_ASON:
+            autoshift_enable();
+            return true;
+        case KC_ASOFF:
+            autoshift_disable();
+            return true;
 
 #ifndef NO_AUTO_SHIFT_ALPHA
-      case KC_A:
-      case KC_B:
-      case KC_C:
-      case KC_D:
-      case KC_E:
-      case KC_F:
-      case KC_G:
-      case KC_H:
-      case KC_I:
-      case KC_J:
-      case KC_K:
-      case KC_L:
-      case KC_M:
-      case KC_N:
-      case KC_O:
-      case KC_P:
-      case KC_Q:
-      case KC_R:
-      case KC_S:
-      case KC_T:
-      case KC_U:
-      case KC_V:
-      case KC_W:
-      case KC_X:
-      case KC_Y:
-      case KC_Z:
+        case KC_A ... KC_Z:
 #endif
 #ifndef NO_AUTO_SHIFT_NUMERIC
-      case KC_1:
-      case KC_2:
-      case KC_3:
-      case KC_4:
-      case KC_5:
-      case KC_6:
-      case KC_7:
-      case KC_8:
-      case KC_9:
-      case KC_0:
+        case KC_1 ... KC_0:
 #endif
 #ifndef NO_AUTO_SHIFT_SPECIAL
-      case KC_MINUS:
-      case KC_EQL:
-      case KC_TAB:
-      case KC_LBRC:
-      case KC_RBRC:
-      case KC_BSLS:
-      case KC_SCLN:
-      case KC_QUOT:
-      case KC_COMM:
-      case KC_DOT:
-      case KC_SLSH:
-      case KC_GRAVE:
-      case KC_NONUS_BSLASH:
-      case KC_NONUS_HASH:
+        case KC_MINUS ... KC_SLASH:
 #endif
 
-        autoshift_flush();
-        if (!autoshift_enabled) return true;
+            autoshift_flush();
+            if (!autoshift_enabled) return true;
 
 #ifndef AUTO_SHIFT_MODIFIERS
-        any_mod_pressed = get_mods() & (
-          MOD_BIT(KC_LGUI)|MOD_BIT(KC_RGUI)|
-          MOD_BIT(KC_LALT)|MOD_BIT(KC_RALT)|
-          MOD_BIT(KC_LCTL)|MOD_BIT(KC_RCTL)|
-          MOD_BIT(KC_LSFT)|MOD_BIT(KC_RSFT)
-        );
-
-        if (any_mod_pressed) {
-          return true;
-        }
+            if (get_mods()) {
+                return true;
+            }
 #endif
 
-        autoshift_on(keycode);
-        return false;
+            autoshift_on(keycode);
 
-      default:
+            // We need some extra handling here for OSL edge cases
+#if !defined(NO_ACTION_ONESHOT) && !defined(NO_ACTION_TAPPING)
+            clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
+#endif
+            return false;
+
+        default:
+            autoshift_flush();
+            return true;
+        }
+    } else {
         autoshift_flush();
-        return true;
     }
-  } else {
-    autoshift_flush();
-  }
 
-  return true;
+    return true;
 }
 
 #endif

--- a/quantum/process_keycode/process_auto_shift.h
+++ b/quantum/process_keycode/process_auto_shift.h
@@ -14,13 +14,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef PROCESS_AUTO_SHIFT_H
-#define PROCESS_AUTO_SHIFT_H
+#pragma once
 
 #include "quantum.h"
 
 #ifndef AUTO_SHIFT_TIMEOUT
-  #define AUTO_SHIFT_TIMEOUT 175
+#   define AUTO_SHIFT_TIMEOUT 175
 #endif
 
 bool process_auto_shift(uint16_t keycode, keyrecord_t *record);
@@ -28,6 +27,6 @@ bool process_auto_shift(uint16_t keycode, keyrecord_t *record);
 void autoshift_enable(void);
 void autoshift_disable(void);
 void autoshift_toggle(void);
-bool autoshift_state(void);
-
-#endif
+bool get_autoshift_state(void);
+uint16_t get_autoshift_timeout(void);
+void set_autoshift_timeout(uint16_t timeout);


### PR DESCRIPTION
* Fix edge case when using One Shot Layer with Auto Shift, and it not triggering the cleanup
* Remove junk code (no longer used)
* Replace `(un)register_code` calls with `tap_code` where appropriate
* Fixed up Switch check to be more readable (less verbose)
* Simplified modifier check (if it comes back non-zero, there are mods)
* Add additional function calls for autoshift settings
* Made all variables static, since there are function calls to get their status
* Fixed up documentation


(isn't merged to QMK upstream yet)
