### PR TITLE
upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     dfu-programmer \
     dfu-util \
     gcc \
-    gcc-arm-none-eabi \
     gcc-avr \
     git \
     libnewlib-arm-none-eabi \
@@ -18,6 +17,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     wget \
     zip \
     && rm -rf /var/lib/apt/lists/*
+
+# upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtime issues
+RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2 -O - | \
+    tar xj --strip-components=1 -C /
 
 VOLUME /qmk_firmware
 WORKDIR /qmk_firmware

--- a/changelog.md
+++ b/changelog.md
@@ -28,3 +28,4 @@
 05-29-2019 - Fixing matrix_scan so it properly returns changed status  
 05-29-2019 - Add belgian layour for sendstring (qmk#6008)  
 06-03-2019 - Overhaul of AutoShift feature (qmk#6067)  
+06-05-2019 - upgrade gcc-arm-none-eabi from the default 5.4.1 to 6.3.1 due to ARM runtine issues


### PR DESCRIPTION
This isn't strictly necessary, but to keep in lockstep with QMK Firmware