### PR TITLE
Change from avr-gcc@7 to 8 for Mac

### DIFF
--- a/util/macos_install.sh
+++ b/util/macos_install.sh
@@ -22,5 +22,5 @@ fi
 brew tap osx-cross/avr
 brew tap PX4/homebrew-px4
 brew update
-brew install avr-gcc@7 gcc-arm-none-eabi dfu-programmer avrdude dfu-util python3
-brew link --force avr-gcc@7
+brew install avr-gcc@8 gcc-arm-none-eabi dfu-programmer avrdude dfu-util python3
+brew link --force avr-gcc@8


### PR DESCRIPTION
This upgrades the MacOS install script to use the version 8 gcc binaries, since these work now. 

Mostly to keep in lockstep, with upstream