### PR TITLE
Enable RGB Matrix Sleep functionality

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -209,6 +209,17 @@ const keypos_t hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
 #endif
 
 #ifdef RGB_MATRIX_ENABLE
+
+void suspend_power_down_kb(void) {
+    rgb_matrix_set_suspend_state(true);
+    suspend_power_down_user();
+}
+
+void suspend_wakeup_init_kb(void) {
+    rgb_matrix_set_suspend_state(false);
+    suspend_wakeup_init_user();
+}
+
 const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
 /*   driver
  *   |  R location

--- a/keyboards/planck/ez/ez.c
+++ b/keyboards/planck/ez/ez.c
@@ -16,6 +16,17 @@
 #include "ez.h"
 
 #ifdef RGB_MATRIX_ENABLE
+
+void suspend_power_down_kb(void) {
+    rgb_matrix_set_suspend_state(true);
+    suspend_power_down_user();
+}
+
+void suspend_wakeup_init_kb(void) {
+    rgb_matrix_set_suspend_state(false);
+    suspend_wakeup_init_user();
+}
+
 const is31_led g_is31_leds[DRIVER_LED_TOTAL] = {
 /* Refer to IS31 manual for these locations
  *   driver


### PR DESCRIPTION
Right now, the option is enabled for RGB Sleep for the RGB Matrix feature. 

~~But it requires some additional functionality to properly support this.~~

I've added the KB level functions to the keyboard code to both the Planck and Ergodox, so that when the host sends the sleep status, it properly turns off the LEDs. 


