### PR TITLE
Fix compilation error when I2C and encoder is enabled for split code

### DIFF
--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -74,7 +74,7 @@ bool transport_master(matrix_row_t matrix[]) {
 #  endif
 
 #  ifdef ENCODER_ENABLE
-  i2c_readReg(SLAVE_I2C_ADDRESS, I2C_ENCODER_START, (void *)i2c_buffer->encoder_state, sizeof(I2C_slave_buffer_t.encoder_state), TIMEOUT);
+  i2c_readReg(SLAVE_I2C_ADDRESS, I2C_ENCODER_START, (void *)i2c_buffer->encoder_state, sizeof(i2c_buffer->encoder_state), TIMEOUT);
   encoder_update_raw(i2c_buffer->encoder_state);
 #  endif
 


### PR DESCRIPTION
Fixes a compiler issue for Split Common code. 

We don't use this ATM, but to keep in lockstep. 