### PR TITLE
Removed doubled lines in eager_pk.c

### DIFF
--- a/quantum/debounce/eager_pk.c
+++ b/quantum/debounce/eager_pk.c
@@ -98,7 +98,6 @@ void transfer_matrix_values(matrix_row_t raw[], matrix_row_t cooked[], uint8_t n
       matrix_row_t col_mask = (ROW_SHIFTER << col);
       if (delta & col_mask) {
         if (*debounce_pointer == DEBOUNCE_ELAPSED) {
-        counters_need_update = true;	          *debounce_pointer    = current_time;
           *debounce_pointer    = current_time;
           counters_need_update = true;
           existing_row ^= col_mask;  // flip the bit.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
Did a small review of the current debounce algos for the ergodox-ez keyboard.
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I found two lines which are doubled in the code.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
