### PR TITLE
Use QUANTUM_LIB_SRC for i2c_master.c inclusion (qmk#5617)

### DIFF
--- a/common_features.mk
+++ b/common_features.mk
@@ -133,7 +133,7 @@ ifeq ($(strip $(LED_MATRIX_ENABLE)), IS31FL3731)
     OPT_DEFS += -DIS31FL3731
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3731-simple.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 RGB_MATRIX_ENABLE ?= no
@@ -157,21 +157,21 @@ ifeq ($(strip $(RGB_MATRIX_ENABLE)), IS31FL3731)
     OPT_DEFS += -DIS31FL3731 -DSTM32_I2C -DHAL_USE_I2C=TRUE
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3731.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), IS31FL3733)
     OPT_DEFS += -DIS31FL3733 -DSTM32_I2C -DHAL_USE_I2C=TRUE
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3733.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), IS31FL3737)
     OPT_DEFS += -DIS31FL3737 -DSTM32_I2C -DHAL_USE_I2C=TRUE
     COMMON_VPATH += $(DRIVER_PATH)/issi
     SRC += is31fl3737.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 ifeq ($(strip $(RGB_MATRIX_ENABLE)), WS2812)
@@ -271,7 +271,7 @@ ifeq ($(strip $(HAPTIC_ENABLE)), DRV2605L)
     COMMON_VPATH += $(DRIVER_PATH)/haptic
     SRC += haptic.c
     SRC += DRV2605L.c
-    SRC += i2c_master.c
+    QUANTUM_LIB_SRC += i2c_master.c
     OPT_DEFS += -DHAPTIC_ENABLE
     OPT_DEFS += -DDRV2605L
 endif

--- a/drivers/qwiic/qwiic.mk
+++ b/drivers/qwiic/qwiic.mk
@@ -2,9 +2,7 @@ ifneq ($(strip $(QWIIC_ENABLE)),)
   COMMON_VPATH += $(DRIVER_PATH)/qwiic
   OPT_DEFS += -DQWIIC_ENABLE
   SRC += qwiic.c
-  ifeq ($(filter "i2c_master.c", $(SRC)),)
-    SRC += i2c_master.c
-  endif
+  QUANTUM_LIB_SRC += i2c_master.c
 endif
 
 ifneq ($(filter JOYSTIIC, $(QWIIC_ENABLE)),)

--- a/keyboards/ergodox_ez/rules.mk
+++ b/keyboards/ergodox_ez/rules.mk
@@ -16,6 +16,7 @@
 
 # # project specific files
 SRC += matrix.c
+QUANTUM_LIB_SRC += i2c_master.c
 
 # MCU name
 MCU = atmega32u4
@@ -84,10 +85,5 @@ API_SYSEX_ENABLE = no
 RGBLIGHT_ENABLE = yes
 RGB_MATRIX_ENABLE = no # enable later
 DEBOUNCE_TYPE = eager_pr
-
-ifeq ($(strip $(RGB_MATRIX_ENABLE)), no)
-  SRC += i2c_master.c
-endif
-
 
 LAYOUTS = ergodox


### PR DESCRIPTION
This changes all of the `SRC += i2c_master.c` to use `QUANTUM_LIB_SRC`.  This has a number of benefits. However the important two are: 
1. No more errors when the file is added multiple times when compiling (eg for the ergodox EZ glow)
2. Prevents LTO issues with hardware interupts (which may be the remaining issue with the ergodox debounce issue)