### PR TITLE
Fix unselect_rows() in quantum/matrix.c

### DIFF
--- a/quantum/matrix.c
+++ b/quantum/matrix.c
@@ -183,7 +183,7 @@ static void unselect_row(uint8_t row)
 static void unselect_rows(void)
 {
     for(uint8_t x = 0; x < MATRIX_ROWS; x++) {
-        setPinInput(row_pins[x]);
+        setPinInputHigh(row_pins[x]);
     }
 }
 


### PR DESCRIPTION
unselect_col() uses setPinInputHigh(), but unselect_cols() uses setPinInput().
This is not correct. unselect_cols() should also use setPinInputHigh().