### PR TITLE
Add makefile rules to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,9 +19,11 @@ indent_size = 4
 # Make these match what we have in .gitattributes
 [*.mk]
 end_of_line = lf
+indent_style = tab
 
 [Makefile]
 end_of_line = lf
+indent_style = tab
 
 [*.sh]
 end_of_line = lf


### PR DESCRIPTION
# Description
Without this, VSCode and others default to 4x spaces, which breaks make. OMFG was this annoying.