### PR TITLE
Add GPL3 header to avr i2c files

### DIFF
--- a/drivers/avr/i2c_master.c
+++ b/drivers/avr/i2c_master.c
@@ -1,3 +1,18 @@
+/*  Copyright (C) 2019 Elia Ritterbusch
+ +
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 /* Library made by: g4lvanix
  * Github repository: https://github.com/g4lvanix/I2C-master-lib
  */

--- a/drivers/avr/i2c_master.h
+++ b/drivers/avr/i2c_master.h
@@ -1,3 +1,18 @@
+/*  Copyright (C) 2019 Elia Ritterbusch
+ +
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 /* Library made by: g4lvanix
  * Github repository: https://github.com/g4lvanix/I2C-master-lib
  */

--- a/drivers/avr/i2c_slave.c
+++ b/drivers/avr/i2c_slave.c
@@ -1,3 +1,18 @@
+/*  Copyright (C) 2019 Elia Ritterbusch
+ +
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 /* Library made by: g4lvanix
  * Github repository: https://github.com/g4lvanix/I2C-slave-lib
  */

--- a/drivers/avr/i2c_slave.h
+++ b/drivers/avr/i2c_slave.h
@@ -1,3 +1,18 @@
+/*  Copyright (C) 2019 Elia Ritterbusch
+ +
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
 /* Library made by: g4lvanix
  * Github repository: https://github.com/g4lvanix/I2C-slave-lib
 


### PR DESCRIPTION
Update the avr i2c file's headers, since they've been officially licensed. 