### PR TITLE
add 'objs-size' target into tmk_core/avr.mk (qmk#5490)

### DIFF
--- a/build_keyboard.mk
+++ b/build_keyboard.mk
@@ -392,6 +392,7 @@ $(KEYBOARD_OUTPUT)_CONFIG := $(PROJECT_CONFIG)
 all: build check-size
 build: elf cpfirmware
 check-size: build
+objs-size: build
 
 include show_options.mk
 include $(TMK_PATH)/rules.mk

--- a/tmk_core/rules.mk
+++ b/tmk_core/rules.mk
@@ -390,6 +390,9 @@ show_path:
 	@echo SRC=$(SRC)
 	@echo OBJ=$(OBJ)
 
+objs-size:
+	for i in $(OBJ); do echo $$i; done | sort | xargs $(SIZE)
+
 ifeq ($(findstring avr-gcc,$(CC)),avr-gcc)
 SIZE_MARGIN = 1024
 


### PR DESCRIPTION
## Description
Adds new target that is useful for debugging and deep diving into firmware stuff