### PR TITLE
Add out of bound check for Leader Key sequence array (qmk#5840)

### DIFF
--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -17,9 +17,7 @@
 #ifdef LEADER_ENABLE
 
 #include "process_leader.h"
-#ifdef __arm__
-#   include <string.h>
-#endif
+#include <string.h>
 
 #ifndef LEADER_TIMEOUT
   #define LEADER_TIMEOUT 300

--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -17,6 +17,9 @@
 #ifdef LEADER_ENABLE
 
 #include "process_leader.h"
+#ifdef __arm__
+#   include <string.h>
+#endif
 
 #ifndef LEADER_TIMEOUT
   #define LEADER_TIMEOUT 300
@@ -41,11 +44,7 @@ void qk_leader_start(void) {
   leading = true;
   leader_time = timer_read();
   leader_sequence_size = 0;
-  leader_sequence[0] = 0;
-  leader_sequence[1] = 0;
-  leader_sequence[2] = 0;
-  leader_sequence[3] = 0;
-  leader_sequence[4] = 0;
+  memset(leader_sequence, 0, sizeof(leader_sequence));
 }
 
 bool process_leader(uint16_t keycode, keyrecord_t *record) {
@@ -58,8 +57,13 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
           keycode = keycode & 0xFF;
         }
 #endif // LEADER_KEY_STRICT_KEY_PROCESSING
-        leader_sequence[leader_sequence_size] = keycode;
-        leader_sequence_size++;
+        if ( leader_sequence_size < ( sizeof(leader_sequence) / sizeof(leader_sequence[0]) ) ) {
+          leader_sequence[leader_sequence_size] = keycode;
+          leader_sequence_size++;
+        } else {
+          leading = false;
+          leader_end();
+        }
 #ifdef LEADER_PER_KEY_TIMING
         leader_time = timer_read();
 #endif


### PR DESCRIPTION
## Description
This fixes an edge case where hitting more than 5 keys quickly would cause the leader key feature to lock up the keyboard.