### PR TITLE
Configure Vagrant to use qmk_base_container (qmk#6194)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,26 +50,37 @@ Vagrant.configure(2) do |config|
   end
 
   # Docker provider pulls from hub.docker.com respecting docker.image if
-  # config.vm.box is nil. Note that this bind-mounts from the current dir to
+  # config.vm.box is nil. In this case, we adhoc build util/vagrant/Dockerfile.
+  # Note that this bind-mounts from the current dir to
   # /vagrant in the guest, so unless your UID is 1000 to match vagrant in the
   # image, you'll need to: chmod -R a+rw .
   config.vm.provider "docker" do |docker, override|
     override.vm.box = nil
-    docker.image = "jesselang/debian-vagrant:stretch"
+    docker.build_dir = "util/vagrant"
     docker.has_ssh = true
   end
 
-  # This script ensures the required packages for AVR programming are installed
-  # It also ensures the system always gets the latest updates when powered on
-  # If this causes issues you can run a 'vagrant destroy' and then
-  # add a # before ,run: (or change "always" to "once") and run 'vagrant up' to get a working
-  # non-updated box and then attempt to troubleshoot or open a Github issue
-  config.vm.provision "shell", inline: "/bin/sh -c 'yes | /vagrant/util/qmk_install.sh'", run: "always"
+  # Unless we are running the docker container directly
+  #   1. run container detached on vm
+  #   2. attach on 'vagrant ssh'
+  ["virtualbox", "vmware_workstation", "vmware_fusion"].each do |type|
+    config.vm.provider type do |virt, override|
+      override.vm.provision "docker" do |d|
+        d.run "qmkfm/base_container",
+          cmd: "tail -f /dev/null",
+          args: "--privileged -v /dev:/dev -v '/vagrant:/vagrant'"
+      end
+
+      override.vm.provision "shell", inline: <<-SHELL
+        echo 'docker restart qmkfm-base_container && exec docker exec -it qmkfm-base_container /bin/bash -l' >> ~vagrant/.bashrc
+      SHELL
+    end
+  end
 
   config.vm.post_up_message = <<-EOT
 
-  Log into the VM using 'vagrant ssh'. QMK directory synchronized with host is
-  located at /vagrant
+  Log into the environment using 'vagrant ssh'. QMK directory synchronized with
+  host is located at /vagrant
   To compile the .hex files use make command inside this directory, e.g.
      cd /vagrant
      make <keyboard>:default

--- a/util/vagrant/Dockerfile
+++ b/util/vagrant/Dockerfile
@@ -1,0 +1,33 @@
+FROM qmkfm/base_container
+
+# Basic upgrades; install sudo and SSH.
+RUN apt-get update && apt-get install --no-install-recommends -y \
+        sudo \
+        openssh-server \
+    && rm -rf /var/lib/apt/lists/*
+RUN mkdir /var/run/sshd
+RUN sed -i 's/PermitRootLogin yes/PermitRootLogin no/' /etc/ssh/sshd_config
+RUN echo 'UseDNS no' >> /etc/ssh/sshd_config
+
+# Remove the policy file once we're finished installing software.
+# This allows invoke-rc.d and friends to work as expected.
+RUN rm /usr/sbin/policy-rc.d
+
+# Add the Vagrant user and necessary passwords.
+RUN groupadd vagrant
+RUN useradd -c "Vagrant" -g vagrant -d /home/vagrant -m -s /bin/bash vagrant
+RUN echo 'root:vagrant' | chpasswd
+RUN echo 'vagrant:vagrant' | chpasswd
+
+# Allow the vagrant user to use sudo without a password.
+RUN echo 'vagrant ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/vagrant
+
+# Install Vagrant's insecure public key so provisioning and 'vagrant ssh' work.
+RUN mkdir /home/vagrant/.ssh
+ADD https://raw.githubusercontent.com/mitchellh/vagrant/master/keys/vagrant.pub /home/vagrant/.ssh/authorized_keys
+RUN chmod 0600 /home/vagrant/.ssh/authorized_keys
+RUN chown -R vagrant:vagrant /home/vagrant/.ssh
+RUN chmod 0700 /home/vagrant/.ssh
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/util/vagrant/readme.md
+++ b/util/vagrant/readme.md
@@ -1,0 +1,12 @@
+# QMK Vagrant Utilities
+
+## Dockerfile
+Vagrant-friendly `qmkfm/base_container`.
+
+In order for the Docker provider and `vagrant ssh` to function the container has a few extra requirements.
+
+* vagrant user
+* ssh server
+  * configured with expected public key
+* sudo
+  * passwordless for vagrant user


### PR DESCRIPTION
## Description
This updates the Vagrant build stuff to use the QMK controlled container rather than some random persons.