### PR TITLE
Expand bootloader target to support most AVR boards (qmk#6255)

### DIFF
--- a/lib/lufa/Bootloaders/DFU/makefile
+++ b/lib/lufa/Bootloaders/DFU/makefile
@@ -11,11 +11,11 @@
 
 # Run "make help" for target help.
 
-MCU          = atmega32u4
-ARCH         = AVR8
-BOARD        = QMK
-F_CPU        = 16000000
-F_USB        = $(F_CPU)
+MCU          ?= atmega32u4
+ARCH         ?= AVR8
+BOARD        ?= QMK
+F_CPU        ?= 16000000
+F_USB        ?= $(F_CPU)
 OPTIMIZATION = s
 TARGET       = BootloaderDFU
 SRC          = $(TARGET).c Descriptors.c BootloaderAPI.c BootloaderAPITable.S $(LUFA_SRC_USB)
@@ -26,8 +26,8 @@ LD_FLAGS     = -Wl,--section-start=.text=$(BOOT_START_OFFSET) $(BOOT_API_LD_FLAG
 # Flash size and bootloader section sizes of the target, in KB. These must
 # match the target's total FLASH size and the bootloader size set in the
 # device's fuses.
-FLASH_SIZE_KB         = 32
-BOOT_SECTION_SIZE_KB  = 4
+FLASH_SIZE_KB         ?= 32
+BOOT_SECTION_SIZE_KB  ?= 4
 
 # Bootloader address calculation formulas
 # Do not modify these macros, but rather modify the dependent values above.

--- a/tmk_core/avr.mk
+++ b/tmk_core/avr.mk
@@ -306,7 +306,11 @@ extcoff: $(BUILD_DIR)/$(TARGET).elf
 bootloader:
 	make -C lib/lufa/Bootloaders/DFU/ clean
 	$(TMK_DIR)/make_dfu_header.sh $(ALL_CONFIGS)
-	make -C lib/lufa/Bootloaders/DFU/
+	$(eval MAX_SIZE=$(shell n=`$(CC) -E -mmcu=$(MCU) $(CFLAGS) $(OPT_DEFS) tmk_core/common/avr/bootloader_size.c 2> /dev/null | sed -ne '/^#/n;/^AVR_SIZE:/,$${s/^AVR_SIZE: //;p;}'` && echo $$(($$n)) || echo 0))
+	$(eval PROGRAM_SIZE_KB=$(shell n=`expr $(MAX_SIZE) / 1024` && echo $$(($$n)) || echo 0))
+	$(eval BOOT_SECTION_SIZE_KB=$(shell n=`expr  $(BOOTLOADER_SIZE) / 1024` && echo $$(($$n)) || echo 0))
+	$(eval FLASH_SIZE_KB=$(shell n=`expr $(PROGRAM_SIZE_KB) + $(BOOT_SECTION_SIZE_KB)` && echo $$(($$n)) || echo 0))
+	make -C lib/lufa/Bootloaders/DFU/ MCU=$(MCU) ARCH=$(ARCH) F_CPU=$(F_CPU) FLASH_SIZE_KB=$(FLASH_SIZE_KB) BOOT_SECTION_SIZE_KB=$(BOOT_SECTION_SIZE_KB)
 	printf "BootloaderDFU.hex copied to $(TARGET)_bootloader.hex\n"
 	cp lib/lufa/Bootloaders/DFU/BootloaderDFU.hex $(TARGET)_bootloader.hex
 


### PR DESCRIPTION
## Description
Allows the `:bootloader` target to compile for AVR chips other than just the ATmega32u4.

We don't strictly need this, but to keep in lockstep.