### PR TITLE
Allow Combo feature to be enabled/disabled live (qmk#6318)

### DIFF
--- a/quantum/process_keycode/process_combo.c
+++ b/quantum/process_keycode/process_combo.c
@@ -28,6 +28,7 @@ static uint16_t timer = 0;
 static uint8_t current_combo_index = 0;
 static bool drop_buffer = false;
 static bool is_active = false;
+static bool b_combo_enable = true; // defaults to enabled
 
 static uint8_t buffer_size = 0;
 #ifdef COMBO_ALLOW_ACTION_KEYS
@@ -128,6 +129,23 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
   drop_buffer = false;
   bool no_combo_keys_pressed = true;
 
+  if (keycode == CMB_ON && record->event.pressed) {
+    combo_enable();
+    return true;
+  }
+
+  if (keycode == CMB_OFF && record->event.pressed) {
+    combo_disable();
+    return true;
+  }
+
+  if (keycode == CMB_TOG && record->event.pressed) {
+    combo_toggle();
+    return true;
+  }
+
+  if (!is_combo_enabled()) { return true; }
+
   for (current_combo_index = 0; current_combo_index < COMBO_COUNT;
        ++current_combo_index) {
     combo_t *combo = &key_combos[current_combo_index];
@@ -166,7 +184,7 @@ bool process_combo(uint16_t keycode, keyrecord_t *record) {
 }
 
 void matrix_scan_combo(void) {
-  if (is_active && timer && timer_elapsed(timer) > COMBO_TERM) {
+  if (b_combo_enable && is_active && timer && timer_elapsed(timer) > COMBO_TERM) {
 
     /* This disables the combo, meaning key events for this
      * combo will be handled by the next processors in the chain
@@ -174,4 +192,27 @@ void matrix_scan_combo(void) {
     is_active = false;
     dump_key_buffer(true);
   }
+}
+
+void combo_enable(void) {
+    b_combo_enable = true;
+}
+
+void combo_disable(void) {
+    b_combo_enable = is_active = false;
+    timer = 0;
+    dump_key_buffer(true);
+
+}
+
+void combo_toggle(void) {
+    if (b_combo_enable) {
+        combo_disable();
+    } else {
+        combo_enable();
+    }
+}
+
+bool is_combo_enabled(void) {
+    return b_combo_enable;
 }

--- a/quantum/process_keycode/process_combo.h
+++ b/quantum/process_keycode/process_combo.h
@@ -58,4 +58,9 @@ bool process_combo(uint16_t keycode, keyrecord_t *record);
 void matrix_scan_combo(void);
 void process_combo_event(uint8_t combo_index, bool pressed);
 
+void combo_enable(void);
+void combo_disable(void);
+void combo_toggle(void);
+bool is_combo_enabled(void);
+
 #endif

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -489,6 +489,9 @@ enum quantum_keycodes {
     // Right control, close paren
     KC_RAPC,
 
+    CMB_ON,
+    CMB_OFF,
+    CMB_TOG,
     // always leave at the end
     SAFE_RANGE
 };


### PR DESCRIPTION
## Description
Allows the Combo feature to be enabled/disabled without recompiling firmware.