### PR TITLE
Remove the need to specify NUM_OF_ENCODERS for the Encoder feature (qmk#6328)

### DIFF
--- a/keyboards/planck/ez/config.h
+++ b/keyboards/planck/ez/config.h
@@ -43,7 +43,6 @@
 #define MATRIX_ROW_PINS { A10, A9, A8, B15, C13, C14, C15, A2 }
 #define MATRIX_COL_PINS { B11, B10, B2, B1, A7, B0 }
 
-#define NUMBER_OF_ENCODERS 1
 #define ENCODERS_PAD_A { B12 }
 #define ENCODERS_PAD_B { B13 }
 

--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -25,16 +25,14 @@
   #define ENCODER_RESOLUTION 4
 #endif
 
-#ifndef NUMBER_OF_ENCODERS
-  #error "Number of encoders not defined by NUMBER_OF_ENCODERS"
-#endif
-
 #if !defined(ENCODERS_PAD_A) || !defined(ENCODERS_PAD_B)
   #error "No encoder pads defined by ENCODERS_PAD_A and ENCODERS_PAD_B"
 #endif
 
-static pin_t encoders_pad_a[NUMBER_OF_ENCODERS] = ENCODERS_PAD_A;
-static pin_t encoders_pad_b[NUMBER_OF_ENCODERS] = ENCODERS_PAD_B;
+
+#define NUMBER_OF_ENCODERS (sizeof(encoders_pad_a)/sizeof(pin_t))
+static pin_t encoders_pad_a[] = ENCODERS_PAD_A;
+static pin_t encoders_pad_b[] = ENCODERS_PAD_B;
 
 static int8_t encoder_LUT[] = { 0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0 };
 

--- a/quantum/split_common/transport.c
+++ b/quantum/split_common/transport.c
@@ -17,6 +17,8 @@
 
 #ifdef ENCODER_ENABLE
 #  include "encoder.h"
+static pin_t encoders_pad[] = ENCODERS_PAD_A;
+#  define NUMBER_OF_ENCODERS (sizeof(encoders_pad)/sizeof(pin_t))
 #endif
 
 #if defined(USE_I2C) || defined(EH)


### PR DESCRIPTION
## Description
This calculates the number of encoders based on the array defined, rather than needing a hard coded number.