### PR TITLE
Update RGB Matrix configuration for Planck EZ

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -350,6 +350,8 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         case TOGGLE_LAYER_COLOR:
             if (record->event.pressed) {
                 keyboard_config.disable_layer_led ^= 1;
+                if (keyboard_config.disable_layer_led)
+                    rgb_matrix_set_color_all(0, 0, 0);
                 eeconfig_update_kb(keyboard_config.raw);
             }
             break;
@@ -359,6 +361,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 case LED_FLAG_ALL: {
                     rgb_matrix_set_flags(LED_FLAG_NONE);
                     keyboard_config.rgb_matrix_enable = false;
+                    rgb_matrix_set_color_all(0, 0, 0);
                   }
                   break;
                 default: {

--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -109,6 +109,7 @@ inline void ergodox_led_all_set(uint8_t n)
 
 enum ergodox_ez_keycodes {
     LED_LEVEL = SAFE_RANGE,
+    TOGGLE_LAYER_COLOR,
     EZ_SAFE_RANGE,
 };
 
@@ -116,6 +117,8 @@ typedef union {
   uint32_t raw;
   struct {
     uint8_t    led_level :3;
+    bool       disable_layer_led   :1;
+    bool       rgb_matrix_enable   :1;
   };
 } keyboard_config_t;
 

--- a/keyboards/planck/ez/ez.c
+++ b/keyboards/planck/ez/ez.c
@@ -279,6 +279,8 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         case TOGGLE_LAYER_COLOR:
             if (record->event.pressed) {
                 keyboard_config.disable_layer_led ^= 1;
+              if (keyboard_config.disable_layer_led)
+                    rgb_matrix_set_color_all(0, 0, 0);
                 eeconfig_update_kb(keyboard_config.raw);
             }
             break;
@@ -288,6 +290,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 case LED_FLAG_ALL: {
                     rgb_matrix_set_flags(LED_FLAG_NONE);
                     keyboard_config.rgb_matrix_enable = false;
+                    rgb_matrix_set_color_all(0, 0, 0);
                   }
                   break;
                 default: {

--- a/keyboards/planck/ez/ez.h
+++ b/keyboards/planck/ez/ez.h
@@ -60,13 +60,16 @@ void planck_ez_left_led_level(uint8_t level);
 
 enum planck_ez_keycodes {
     LED_LEVEL = SAFE_RANGE,
+    TOGGLE_LAYER_COLOR,
     EZ_SAFE_RANGE,
 };
 
 typedef union {
   uint32_t raw;
   struct {
-    uint8_t    led_level :3;
+    uint8_t      led_level           :3;
+    bool         disable_layer_led   :1;
+    bool         rgb_matrix_enable   :1;
   };
 } keyboard_config_t;
 

--- a/keyboards/planck/keymaps/oryx/keymap.c
+++ b/keyboards/planck/keymaps/oryx/keymap.c
@@ -19,7 +19,6 @@
 
 enum planck_keycodes {
   RGB_SLD = SAFE_RANGE,
-  TOGGLE_LAYER_COLOR,
   EPRM,
 };
 


### PR DESCRIPTION
This uses the built in LED Flags for the RGB Matrix, so we can control the matrix better, without using the HSV hack. 

However, this will require adding a "default" check to the layer indicator function that oryx generates.  Eg: 

```c
void rgb_matrix_indicators_user(void) {
  if (g_suspend_state || keyboard_config.disable_layer_led) { return; }
  switch (biton32(layer_state)) {
    case 1:
      set_layer_color(1);
      break;
    case 2:
      set_layer_color(2);
      break;
    default:
      if (rgb_matrix_get_flags() == LED_FLAG_NONE)
        rgb_matrix_set_color_all(0, 0, 0);
      break;
  }
}
```