### PR TITLE
Fix RGB Matrix Cycle Left-Right Animation (qmk#6421)

### DIFF
--- a/quantum/rgb_matrix.c
+++ b/quantum/rgb_matrix.c
@@ -88,7 +88,7 @@
 #endif
 
 #if !defined(RGB_MATRIX_STARTUP_MODE)
-  #ifndef DISABLE_RGB_MATRIX_CYCLE_ALL
+  #ifndef DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT
     #define RGB_MATRIX_STARTUP_MODE RGB_MATRIX_CYCLE_LEFT_RIGHT
   #else
     // fallback to solid colors if RGB_MATRIX_CYCLE_LEFT_RIGHT is disabled in userspace


### PR DESCRIPTION
One-line fix for a typo that could break build if DISABLE_RGB_MATRIX_CYCLE_LEFT_RIGHT was defined but not DISABLE_RGB_MATRIX_CYCLE_ALL

