### PR TITLE
Fix LT() crashing some ARM keyboards (qmk#6529)

### DIFF
--- a/tmk_core/common/wait.h
+++ b/tmk_core/common/wait.h
@@ -13,8 +13,8 @@ extern "C" {
 #   define wait_us(us)  _delay_us(us)
 #elif defined PROTOCOL_CHIBIOS
 #   include "ch.h"
-#   define wait_ms(ms) chThdSleepMilliseconds(ms)
-#   define wait_us(us) chThdSleepMicroseconds(us)
+#   define wait_ms(ms) do { if (ms != 0) { chThdSleepMilliseconds(ms); } else { chThdSleepMicroseconds(1); } } while (0)
+#   define wait_us(us) do { if (us != 0) { chThdSleepMicroseconds(us); } else { chThdSleepMicroseconds(1); } } while (0)
 #elif defined PROTOCOL_ARM_ATSAM
 #   include "clks.h"
 #   define wait_ms(ms) CLK_delay_ms(ms)


### PR DESCRIPTION
Fixes an issue with some of the code I introduced recently, actually. 