### PR TITLE
fix: shutdown all leds before suspend

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -222,6 +222,7 @@ const keypos_t hand_swap_config[MATRIX_ROWS][MATRIX_COLS] = {
 #ifdef RGB_MATRIX_ENABLE
 
 void suspend_power_down_kb(void) {
+    rgb_matrix_set_color_all(0, 0, 0);
     rgb_matrix_set_suspend_state(true);
     suspend_power_down_user();
 }

--- a/keyboards/planck/ez/ez.c
+++ b/keyboards/planck/ez/ez.c
@@ -22,6 +22,7 @@ keyboard_config_t keyboard_config;
 
 #ifdef RGB_MATRIX_ENABLE
 void suspend_power_down_kb(void) {
+    rgb_matrix_set_color_all(0, 0, 0);
     rgb_matrix_set_suspend_state(true);
     suspend_power_down_user();
 }


### PR DESCRIPTION
Sometimes, when the host computer goes to sleep and when `RGB_DISABLE_WHEN_USB_SUSPENDED` is set to `true`, some leds would randomly still be on.