### PR TITLE
Add support for different encoder pinout for right half of split keyboard (#6521)

### DIFF
--- a/quantum/encoder.c
+++ b/quantum/encoder.c
@@ -16,6 +16,9 @@
  */
 
 #include "encoder.h"
+#ifdef SPLIT_KEYBOARD
+  #include "split_util.h"
+#endif
 
 // for memcpy
 #include <string.h>
@@ -54,6 +57,17 @@ void encoder_update_kb(int8_t index, bool clockwise) {
 }
 
 void encoder_init(void) {
+#if defined(SPLIT_KEYBOARD) && defined(ENCODERS_PAD_A_RIGHT) && defined(ENCODERS_PAD_B_RIGHT)
+  if (!isLeftHand) {
+    const pin_t encoders_pad_a_right[] = ENCODERS_PAD_A_RIGHT;
+    const pin_t encoders_pad_b_right[] = ENCODERS_PAD_B_RIGHT;
+    for (uint8_t i = 0; i < NUMBER_OF_ENCODERS; i++) {
+      encoders_pad_a[i] = encoders_pad_a_right[i];
+      encoders_pad_b[i] = encoders_pad_b_right[i];
+    }
+  }
+#endif
+
   for (int i = 0; i < NUMBER_OF_ENCODERS; i++) {
     setPinInputHigh(encoders_pad_a[i]);
     setPinInputHigh(encoders_pad_b[i]);


### PR DESCRIPTION
To keep in lockstep.  

Allows for different pin wiring for encoder support on splits. 