### PR TITLE
Remove backslashes from template keymap (#6548)

### DIFF
--- a/quantum/template/base/keymaps/default/keymap.c
+++ b/quantum/template/base/keymaps/default/keymap.c
@@ -23,8 +23,8 @@ enum custom_keycodes {
 
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [0] = LAYOUT( /* Base */
-    KC_A,  KC_1,  KC_H, \
-      KC_TAB,  KC_SPC   \
+    KC_A,  KC_1,  KC_H,
+      KC_TAB,  KC_SPC
   ),
 };
 


### PR DESCRIPTION
Fixes up template.   


Mostly to keep in lockstep with upstream. 