### PR TITLE
Add ATmega32U2 to mcu_selection.mk (#6561)

### DIFF
--- a/quantum/mcu_selection.mk
+++ b/quantum/mcu_selection.mk
@@ -36,7 +36,7 @@ ifneq ($(findstring STM32F303, $(MCU)),)
   DFU_SUFFIX_ARGS = -p DF11 -v 0483
 endif
 
-ifneq (,$(filter $(MCU),atmega32u4 at90usb1286))
+ifneq (,$(filter $(MCU),atmega32u2 atmega32u4 at90usb1286))
   # Processor frequency.
   #     This will define a symbol, F_CPU, in all source code files equal to the
   #     processor frequency in Hz. You can then use this symbol in your source code to


### PR DESCRIPTION
Addes better support for additional MCUs.

To keep in lockstep with upstream