### PR TITLE
 Added keycodes for swapping and unswapping the Control and OS keys 

### DIFF
--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -31,6 +31,12 @@ uint16_t keycode_config(uint16_t keycode) {
             if (keymap_config.swap_control_capslock) {
                 return KC_CAPSLOCK;
             }
+            if (keymap_config.swap_lctl_lgui) {
+                if (keymap_config.no_gui) {
+                    return KC_NO;
+                }
+                return KC_LGUI;
+            }
             return KC_LCTL;
         case KC_LALT:
             if (keymap_config.swap_lalt_lgui) {
@@ -44,10 +50,21 @@ uint16_t keycode_config(uint16_t keycode) {
             if (keymap_config.swap_lalt_lgui) {
                 return KC_LALT;
             }
+            if (keymap_config.swap_lctl_lgui) {
+              return KC_LCTRL;
+            }
             if (keymap_config.no_gui) {
                 return KC_NO;
             }
             return KC_LGUI;
+        case KC_RCTL:
+            if (keymap_config.swap_rctl_rgui) {
+                if (keymap_config.no_gui) {
+                    return KC_NO;
+                }
+                return KC_RGUI;
+            }
+            return KC_RCTL;
         case KC_RALT:
             if (keymap_config.swap_ralt_rgui) {
                 if (keymap_config.no_gui) {
@@ -59,6 +76,9 @@ uint16_t keycode_config(uint16_t keycode) {
         case KC_RGUI:
             if (keymap_config.swap_ralt_rgui) {
                 return KC_RALT;
+            }
+            if (keymap_config.swap_rctl_rgui) {
+              return KC_RCTL;
             }
             if (keymap_config.no_gui) {
                 return KC_NO;
@@ -107,6 +127,24 @@ uint8_t mod_config(uint8_t mod) {
             mod &= ~MOD_RALT;
             mod |= MOD_RGUI;
         }
+    }
+    if (keymap_config.swap_lctl_lgui) {
+      if ((mod & MOD_RGUI) == MOD_LGUI) {
+        mod &= ~MOD_LGUI;
+        mod |= MOD_LCTL;
+      } else if ((mod & MOD_RCTL) == MOD_LCTL) {
+        mod &= ~MOD_LCTL;
+        mod |= MOD_LGUI;
+      }
+    }
+    if (keymap_config.swap_rctl_rgui) {
+      if ((mod & MOD_RGUI) == MOD_RGUI) {
+        mod &= ~MOD_RGUI;
+        mod |= MOD_RCTL;
+      } else if ((mod & MOD_RCTL) == MOD_RCTL) {
+        mod &= ~MOD_RCTL;
+        mod |= MOD_RGUI;
+      }
     }
     if (keymap_config.no_gui) {
         mod &= ~MOD_LGUI;

--- a/quantum/keycode_config.c
+++ b/quantum/keycode_config.c
@@ -18,6 +18,11 @@
 
 extern keymap_config_t keymap_config;
 
+/** \brief keycode_config
+ *
+ * This function is used to check a specific keycode against the bootmagic config,
+ * and will return the corrected keycode, when appropriate.
+ */
 uint16_t keycode_config(uint16_t keycode) {
 
     switch (keycode) {
@@ -108,6 +113,12 @@ uint16_t keycode_config(uint16_t keycode) {
             return keycode;
     }
 }
+
+/** \brief mod_config
+ *
+ *  This function checks the mods passed to it against the bootmagic config,
+ *  and will remove or replace mods, based on that.
+ */
 
 uint8_t mod_config(uint8_t mod) {
     if (keymap_config.swap_lalt_lgui) {

--- a/quantum/keycode_config.h
+++ b/quantum/keycode_config.h
@@ -36,6 +36,8 @@ typedef union {
         bool swap_grave_esc:1;
         bool swap_backslash_backspace:1;
         bool nkro:1;
+        bool swap_lctl_lgui:1;
+        bool swap_rctl_rgui:1;
     };
 } keymap_config_t;
 

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -65,9 +65,17 @@ extern backlight_config_t backlight_config;
   #ifndef AG_SWAP_SONG
     #define AG_SWAP_SONG SONG(AG_SWAP_SOUND)
   #endif
+  #ifndef CG_NORM_SONG
+    #define CG_NORM_SONG SONG(AG_NORM_SOUND)
+  #endif
+  #ifndef CG_SWAP_SONG
+    #define CG_SWAP_SONG SONG(AG_SWAP_SOUND)
+  #endif
   float goodbye_song[][2] = GOODBYE_SONG;
   float ag_norm_song[][2] = AG_NORM_SONG;
   float ag_swap_song[][2] = AG_SWAP_SONG;
+  float cg_norm_song[][2] = CG_NORM_SONG;
+  float cg_swap_song[][2] = CG_SWAP_SONG;
   #ifdef DEFAULT_LAYER_SONGS
     float default_layer_songs[][16][2] = DEFAULT_LAYER_SONGS;
   #endif
@@ -559,7 +567,8 @@ bool process_record_quantum(keyrecord_t *record) {
       return false;
     #endif
     #endif
-    case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_TOGGLE_NKRO:
+    case MAGIC_SWAP_CONTROL_CAPSLOCK ... MAGIC_TOGGLE_ALT_GUI:
+    case MAGIC_SWAP_LCTL_LGUI ... MAGIC_TOGGLE_CTL_GUI:
       if (record->event.pressed) {
         // MAGIC actions (BOOTMAGIC without the boot)
         if (!eeconfig_is_enabled()) {
@@ -581,6 +590,12 @@ bool process_record_quantum(keyrecord_t *record) {
           case MAGIC_SWAP_RALT_RGUI:
             keymap_config.swap_ralt_rgui = true;
             break;
+          case MAGIC_SWAP_LCTL_LGUI:
+            keymap_config.swap_lctl_lgui = true;
+            break;
+          case MAGIC_SWAP_RCTL_RGUI:
+            keymap_config.swap_rctl_rgui = true;
+            break;
           case MAGIC_NO_GUI:
             keymap_config.no_gui = true;
             break;
@@ -600,6 +615,13 @@ bool process_record_quantum(keyrecord_t *record) {
               PLAY_SONG(ag_swap_song);
             #endif
             break;
+          case MAGIC_SWAP_CTL_GUI:
+            keymap_config.swap_lctl_lgui = true;
+            keymap_config.swap_rctl_rgui = true;
+            #ifdef AUDIO_ENABLE
+              PLAY_SONG(cg_swap_song);
+            #endif
+            break;
           case MAGIC_UNSWAP_CONTROL_CAPSLOCK:
             keymap_config.swap_control_capslock = false;
             break;
@@ -611,6 +633,12 @@ bool process_record_quantum(keyrecord_t *record) {
             break;
           case MAGIC_UNSWAP_RALT_RGUI:
             keymap_config.swap_ralt_rgui = false;
+            break;
+          case MAGIC_UNSWAP_LCTL_LGUI:
+            keymap_config.swap_lctl_lgui = false;
+            break;
+          case MAGIC_UNSWAP_RCTL_RGUI:
+            keymap_config.swap_rctl_rgui = false;
             break;
           case MAGIC_UNNO_GUI:
             keymap_config.no_gui = false;
@@ -631,6 +659,13 @@ bool process_record_quantum(keyrecord_t *record) {
               PLAY_SONG(ag_norm_song);
             #endif
             break;
+          case MAGIC_UNSWAP_CTL_GUI:
+            keymap_config.swap_lctl_lgui = false;
+            keymap_config.swap_rctl_rgui = false;
+            #ifdef AUDIO_ENABLE
+              PLAY_SONG(cg_norm_song);
+            #endif
+            break;
           case MAGIC_TOGGLE_ALT_GUI:
             keymap_config.swap_lalt_lgui = !keymap_config.swap_lalt_lgui;
             keymap_config.swap_ralt_rgui = !keymap_config.swap_ralt_rgui;
@@ -639,6 +674,17 @@ bool process_record_quantum(keyrecord_t *record) {
                 PLAY_SONG(ag_swap_song);
               } else {
                 PLAY_SONG(ag_norm_song);
+              }
+            #endif
+            break;
+          case MAGIC_TOGGLE_CTL_GUI:
+            keymap_config.swap_lctl_lgui = !keymap_config.swap_lctl_lgui;
+            keymap_config.swap_rctl_rgui = !keymap_config.swap_rctl_rgui;
+            #ifdef AUDIO_ENABLE
+              if (keymap_config.swap_rctl_rgui) {
+                PLAY_SONG(cg_swap_song);
+              } else {
+                PLAY_SONG(cg_norm_song);
               }
             #endif
             break;

--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -609,15 +609,13 @@ bool process_record_quantum(keyrecord_t *record) {
             keymap_config.nkro = true;
             break;
           case MAGIC_SWAP_ALT_GUI:
-            keymap_config.swap_lalt_lgui = true;
-            keymap_config.swap_ralt_rgui = true;
+            keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = true;
             #ifdef AUDIO_ENABLE
               PLAY_SONG(ag_swap_song);
             #endif
             break;
           case MAGIC_SWAP_CTL_GUI:
-            keymap_config.swap_lctl_lgui = true;
-            keymap_config.swap_rctl_rgui = true;
+            keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = true;
             #ifdef AUDIO_ENABLE
               PLAY_SONG(cg_swap_song);
             #endif
@@ -653,22 +651,20 @@ bool process_record_quantum(keyrecord_t *record) {
             keymap_config.nkro = false;
             break;
           case MAGIC_UNSWAP_ALT_GUI:
-            keymap_config.swap_lalt_lgui = false;
-            keymap_config.swap_ralt_rgui = false;
+            keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = false;
             #ifdef AUDIO_ENABLE
               PLAY_SONG(ag_norm_song);
             #endif
             break;
           case MAGIC_UNSWAP_CTL_GUI:
-            keymap_config.swap_lctl_lgui = false;
-            keymap_config.swap_rctl_rgui = false;
+            keymap_config.swap_lctl_lgui = keymap_config.swap_rctl_rgui = false;
             #ifdef AUDIO_ENABLE
               PLAY_SONG(cg_norm_song);
             #endif
             break;
           case MAGIC_TOGGLE_ALT_GUI:
             keymap_config.swap_lalt_lgui = !keymap_config.swap_lalt_lgui;
-            keymap_config.swap_ralt_rgui = !keymap_config.swap_ralt_rgui;
+            keymap_config.swap_ralt_rgui = keymap_config.swap_lalt_lgui;
             #ifdef AUDIO_ENABLE
               if (keymap_config.swap_ralt_rgui) {
                 PLAY_SONG(ag_swap_song);
@@ -679,7 +675,7 @@ bool process_record_quantum(keyrecord_t *record) {
             break;
           case MAGIC_TOGGLE_CTL_GUI:
             keymap_config.swap_lctl_lgui = !keymap_config.swap_lctl_lgui;
-            keymap_config.swap_rctl_rgui = !keymap_config.swap_rctl_rgui;
+            keymap_config.swap_rctl_rgui = keymap_config.swap_lctl_lgui;
             #ifdef AUDIO_ENABLE
               if (keymap_config.swap_rctl_rgui) {
                 PLAY_SONG(cg_swap_song);

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -492,6 +492,15 @@ enum quantum_keycodes {
     CMB_ON,
     CMB_OFF,
     CMB_TOG,
+  
+    MAGIC_SWAP_LCTL_LGUI,
+    MAGIC_SWAP_RCTL_RGUI,
+    MAGIC_UNSWAP_LCTL_LGUI,
+    MAGIC_UNSWAP_RCTL_RGUI,
+    MAGIC_SWAP_CTL_GUI,
+    MAGIC_UNSWAP_CTL_GUI,
+    MAGIC_TOGGLE_CTL_GUI,
+
     // always leave at the end
     SAFE_RANGE
 };
@@ -638,6 +647,10 @@ enum quantum_keycodes {
 #define AG_SWAP MAGIC_SWAP_ALT_GUI
 #define AG_NORM MAGIC_UNSWAP_ALT_GUI
 #define AG_TOGG MAGIC_TOGGLE_ALT_GUI
+
+#define CG_SWAP MAGIC_SWAP_CTL_GUI
+#define CG_NORM MAGIC_UNSWAP_CTL_GUI
+#define CG_TOGG MAGIC_TOGGLE_CTL_GUI
 
 // GOTO layer - 16 layers max
 // when:

--- a/tmk_core/common/command.c
+++ b/tmk_core/common/command.c
@@ -286,6 +286,8 @@ static void print_eeconfig(void)
     print("keymap_config.raw: "); print_hex8(kc.raw); print("\n");
     print(".swap_control_capslock: "); print_dec(kc.swap_control_capslock); print("\n");
     print(".capslock_to_control: "); print_dec(kc.capslock_to_control); print("\n");
+    print(".swap_lctl_lgui: "); print_dec(kc.swap_lctl_lgui); print("\n");
+    print(".swap_rctl_rgui: "); print_dec(kc.swap_rctl_rgui); print("\n");
     print(".swap_lalt_lgui: "); print_dec(kc.swap_lalt_lgui); print("\n");
     print(".swap_ralt_rgui: "); print_dec(kc.swap_ralt_rgui); print("\n");
     print(".no_gui: "); print_dec(kc.no_gui); print("\n");

--- a/tmk_core/common/eeconfig.c
+++ b/tmk_core/common/eeconfig.c
@@ -39,7 +39,8 @@ void eeconfig_init_quantum(void) {
   eeprom_update_byte(EECONFIG_DEBUG,          0);
   eeprom_update_byte(EECONFIG_DEFAULT_LAYER,  0);
   default_layer_state = 0;
-  eeprom_update_byte(EECONFIG_KEYMAP,         0);
+  eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, 0);
+  eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, 0);
   eeprom_update_byte(EECONFIG_MOUSEKEY_ACCEL, 0);
   eeprom_update_byte(EECONFIG_BACKLIGHT,      0);
   eeprom_update_byte(EECONFIG_AUDIO,             0xFF); // On by default
@@ -127,12 +128,17 @@ void eeconfig_update_default_layer(uint8_t val) { eeprom_update_byte(EECONFIG_DE
  *
  * FIXME: needs doc
  */
-uint8_t eeconfig_read_keymap(void)      { return eeprom_read_byte(EECONFIG_KEYMAP); }
+uint16_t eeconfig_read_keymap(void) {
+    return ( eeprom_read_byte(EECONFIG_KEYMAP_LOWER_BYTE) | (eeprom_read_byte(EECONFIG_KEYMAP_UPPER_BYTE) << 8) );
+}
 /** \brief eeconfig update keymap
  *
  * FIXME: needs doc
  */
-void eeconfig_update_keymap(uint8_t val) { eeprom_update_byte(EECONFIG_KEYMAP, val); }
+void eeconfig_update_keymap(uint16_t val) {
+    eeprom_update_byte(EECONFIG_KEYMAP_LOWER_BYTE, val & 0xFF);
+    eeprom_update_byte(EECONFIG_KEYMAP_UPPER_BYTE, ( val >> 8 ) & 0xFF );
+}
 
 /** \brief eeconfig read backlight
  *

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -45,7 +45,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_HAPTIC                            (uint32_t *)24
 #define EECONFIG_RGB_MATRIX                        (uint32_t *)28
 #define EECONFIG_RGB_MATRIX_SPEED                   (uint8_t *)32
-
+// TODO: Combine these into a single word and single block of EEPROM
+#define EECONFIG_KEYMAP_UPPER_BYTE                  (uint8_t *)33
 /* debug bit */
 #define EECONFIG_DEBUG_ENABLE                       (1<<0)
 #define EECONFIG_DEBUG_MATRIX                       (1<<1)
@@ -62,6 +63,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define EECONFIG_KEYMAP_SWAP_BACKSLASH_BACKSPACE    (1<<6)
 #define EECONFIG_KEYMAP_NKRO                        (1<<7)
 
+#define EECONFIG_KEYMAP_LOWER_BYTE EECONFIG_KEYMAP
 
 bool eeconfig_is_enabled(void);
 bool eeconfig_is_disabled(void);
@@ -81,8 +83,8 @@ void eeconfig_update_debug(uint8_t val);
 uint8_t eeconfig_read_default_layer(void);
 void eeconfig_update_default_layer(uint8_t val);
 
-uint8_t eeconfig_read_keymap(void);
-void eeconfig_update_keymap(uint8_t val);
+uint16_t eeconfig_read_keymap(void);
+void eeconfig_update_keymap(uint16_t val);
 
 #ifdef BACKLIGHT_ENABLE
 uint8_t eeconfig_read_backlight(void);

--- a/tmk_core/common/eeconfig.h
+++ b/tmk_core/common/eeconfig.h
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdbool.h>
 
 
-#define EECONFIG_MAGIC_NUMBER                       (uint16_t)0xFEEE
+#define EECONFIG_MAGIC_NUMBER                       (uint16_t)0xFEEF
 #define EECONFIG_MAGIC_NUMBER_OFF                   (uint16_t)0xFFFF
 
 /* EEPROM parameter address */


### PR DESCRIPTION
This adds the option to swap the Control and GUI/OS keys.   This is super, SUPER useful for MacOS.

Additionally, this includes a bit of cleanup of some of the bootmagic codes.

And this increments the EEPROM magic value to ensure that the EEPROM gets reset, due to issues with eeprom initialization. 