### PR TITLE
AVR GPIO macro defines more readable

### DIFF
--- a/quantum/config_common.h
+++ b/quantum/config_common.h
@@ -132,6 +132,16 @@
         #define F7 PINDEF(F, 7)
     #endif
 
+  #ifndef __ASSEMBLER__
+    #define _PIN_ADDRESS(p, offset) _SFR_IO8(ADDRESS_BASE + (p >> PORT_SHIFTER) + offset)
+    // Port X Input Pins Address
+    #define PINx_ADDRESS(p)  _PIN_ADDRESS(p, 0)
+    // Port X Data Direction Register,  0:input 1:output
+    #define DDRx_ADDRESS(p)  _PIN_ADDRESS(p, 1)
+    // Port X Data Register
+    #define PORTx_ADDRESS(p) _PIN_ADDRESS(p, 2)
+  #endif
+
 #elif defined(PROTOCOL_CHIBIOS)
   // Defines mapping for Proton C replacement
   #ifdef CONVERT_TO_PROTON_C

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -149,18 +149,17 @@ extern layer_state_t default_layer_state;
 #if defined(__AVR__)
     typedef uint8_t pin_t;
 
-    #define PIN_ADDRESS(p, offset)  (_SFR_IO8(ADDRESS_BASE + ((p) >> PORT_SHIFTER) + (offset)))
-    #define setPinInput(pin)        (PIN_ADDRESS(pin, 1) &= ~_BV((pin) & 0xF))
-    #define setPinInputHigh(pin)    (PIN_ADDRESS(pin, 1) &= ~_BV((pin) & 0xF), \
-                                     PIN_ADDRESS(pin, 2) |=  _BV((pin) & 0xF))
+    #define setPinInput(pin)        (DDRx_ADDRESS(pin)  &= ~_BV((pin) & 0xF))
+    #define setPinInputHigh(pin)    (DDRx_ADDRESS(pin)  &= ~_BV((pin) & 0xF), \
+                                     PORTx_ADDRESS(pin) |=  _BV((pin) & 0xF))
     #define setPinInputLow(pin)     _Static_assert(0, "AVR processors cannot implement an input as pull low")
-    #define setPinOutput(pin)       (PIN_ADDRESS(pin, 1) |=  _BV((pin) & 0xF))
+    #define setPinOutput(pin)       (DDRx_ADDRESS(pin)  |=  _BV((pin) & 0xF))
 
-    #define writePinHigh(pin)       (PIN_ADDRESS(pin, 2) |=  _BV((pin) & 0xF))
-    #define writePinLow(pin)        (PIN_ADDRESS(pin, 2) &= ~_BV((pin) & 0xF))
+    #define writePinHigh(pin)       (PORTx_ADDRESS(pin) |=  _BV((pin) & 0xF))
+    #define writePinLow(pin)        (PORTx_ADDRESS(pin) &= ~_BV((pin) & 0xF))
     #define writePin(pin, level)    ((level) ? writePinHigh(pin) : writePinLow(pin))
 
-    #define readPin(pin)            ((bool)(PIN_ADDRESS(pin, 0) & _BV((pin) & 0xF)))
+    #define readPin(pin)            ((bool)(PINx_ADDRESS(pin) & _BV((pin) & 0xF)))
 #elif defined(PROTOCOL_CHIBIOS)
     typedef ioline_t pin_t;
 


### PR DESCRIPTION
* A little easier to read the definition of the GPIO control macro for AVR.

* Changed to not use GNU statement expression extension.

* Modified split_common/serial.c to use qmk_firmware standard GPIO control macro.

* fix PE6 -> E6

* remove some space

* add some comment to config_common.h

* Changed split_common/serial.c to use a newer version of qmk_firmware standard GPIO control macro.