### PR TITLE
Generalize Tap Dance Layer functions (#6629)

### DIFF
--- a/quantum/process_keycode/process_tap_dance.c
+++ b/quantum/process_keycode/process_tap_dance.c
@@ -71,7 +71,7 @@ void qk_tap_dance_dual_role_finished(qk_tap_dance_state_t *state, void *user_dat
     if (state->count == 1) {
         register_code16(pair->kc);
     } else if (state->count == 2) {
-        layer_move(pair->layer);
+        pair->layer_function(pair->layer);
     }
 }
 

--- a/quantum/process_keycode/process_tap_dance.h
+++ b/quantum/process_keycode/process_tap_dance.h
@@ -56,13 +56,19 @@ typedef struct {
 typedef struct {
     uint16_t kc;
     uint8_t  layer;
+    void (*layer_function)(uint8_t);
 } qk_tap_dance_dual_role_t;
 
 #    define ACTION_TAP_DANCE_DOUBLE(kc1, kc2) \
         { .fn = {qk_tap_dance_pair_on_each_tap, qk_tap_dance_pair_finished, qk_tap_dance_pair_reset}, .user_data = (void *)&((qk_tap_dance_pair_t){kc1, kc2}), }
 
 #    define ACTION_TAP_DANCE_DUAL_ROLE(kc, layer) \
-        { .fn = {qk_tap_dance_dual_role_on_each_tap, qk_tap_dance_dual_role_finished, qk_tap_dance_dual_role_reset}, .user_data = (void *)&((qk_tap_dance_dual_role_t){kc, layer}), }
+        { .fn = { qk_tap_dance_dual_role_on_each_tap, qk_tap_dance_dual_role_finished, qk_tap_dance_dual_role_reset }, .user_data = (void *)&((qk_tap_dance_dual_role_t) { kc, layer, layer_move }),  }
+
+#    define ACTION_TAP_DANCE_TOGGLE_LAYER(kc, layer) \
+        { .fn = { NULL, qk_tap_dance_dual_role_finished, qk_tap_dance_dual_role_reset }, .user_data = (void *)&((qk_tap_dance_dual_role_t) { kc, layer, layer_invert }), }
+
+#    define ACTION_TAP_DANCE_LAYER_MOVE(kc, layer) ACTION_TAP_DANCE_DUAL_ROLE(kc, layer)
 
 #    define ACTION_TAP_DANCE_FN(user_fn) \
         { .fn = {NULL, user_fn, NULL}, .user_data = NULL, }
@@ -72,6 +78,8 @@ typedef struct {
 
 #    define ACTION_TAP_DANCE_FN_ADVANCED_TIME(user_fn_on_each_tap, user_fn_on_dance_finished, user_fn_on_dance_reset, tap_specific_tapping_term) \
         { .fn = {user_fn_on_each_tap, user_fn_on_dance_finished, user_fn_on_dance_reset}, .user_data = NULL, .custom_tapping_term = tap_specific_tapping_term, }
+
+
 
 extern qk_tap_dance_action_t tap_dance_actions[];
 


### PR DESCRIPTION
Allows for layer_move ("TO"), and layer_invert ("TG") for default dances. 

Mostly to keep in lockstep