### PR TITLE
Correct casing for DS_Store in .gitignore (#6787)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ quantum/version.h
 CMakeLists.txt
 cmake-build-debug
 doxygen/
-.DS_STORE
+.DS_Store
 /util/wsl_downloaded
 /util/win_downloaded
 /users/


### PR DESCRIPTION
Fixes gitignore, for sanity's sake 