### PR TITLE
Fix qmk doctor 'bytes-like object is required' on linux

### DIFF
--- a/lib/python/qmk/cli/doctor.py
+++ b/lib/python/qmk/cli/doctor.py
@@ -49,7 +49,7 @@ def main(cli):
     elif OS == "Linux":
         cli.log.info("Detected {fg_cyan}Linux.")
         if shutil.which('systemctl'):
-            mm_check = subprocess.run(['systemctl', 'list-unit-files'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10)
+            mm_check = subprocess.run(['systemctl', 'list-unit-files'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=10, universal_newlines=True)
             if mm_check.returncode == 0:
                 mm = True
                 for line in mm_check.stdout.split('\n'):


### PR DESCRIPTION
This fixes the following issue related to encoding on linux systems. Add
`universal_newlines=True` to subprocess.

<class 'TypeError'>
☒ a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/milc.py", line 564, in __call__
    return self.__call__()
  File "/usr/local/lib/python3.7/site-packages/milc.py", line 569, in __call__
    return self._entrypoint(self)
  File "$HOME/qmk_firmware/lib/python/qmk/cli/doctor.py", line 56, in doctor
    for line in mm_check.stdout.split('\n'):
TypeError: a bytes-like object is required, not 'str'