### PR TITLE
Fix bug in `do_code16()` (#6935)

### DIFF
--- a/quantum/quantum.c
+++ b/quantum/quantum.c
@@ -89,44 +89,28 @@ static void do_code16(uint16_t code, void (*f)(uint8_t)) {
             return;
     }
 
-    if (code & QK_LCTL) f(KC_LCTL);
-    if (code & QK_LSFT) f(KC_LSFT);
-    if (code & QK_LALT) f(KC_LALT);
-    if (code & QK_LGUI) f(KC_LGUI);
+    uint8_t mods_to_send = 0;
 
-    if (code < QK_RMODS_MIN) return;
+    if (code & QK_RMODS_MIN) { // Right mod flag is set
+        if (code & QK_LCTL) mods_to_send |= MOD_BIT(KC_RCTL);
+        if (code & QK_LSFT) mods_to_send |= MOD_BIT(KC_RSFT);
+        if (code & QK_LALT) mods_to_send |= MOD_BIT(KC_RALT);
+        if (code & QK_LGUI) mods_to_send |= MOD_BIT(KC_RGUI);
+    } else {
+        if (code & QK_LCTL) mods_to_send |= MOD_BIT(KC_LCTL);
+        if (code & QK_LSFT) mods_to_send |= MOD_BIT(KC_LSFT);
+        if (code & QK_LALT) mods_to_send |= MOD_BIT(KC_LALT);
+        if (code & QK_LGUI) mods_to_send |= MOD_BIT(KC_LGUI);
+    }
 
-    if (code & QK_RCTL) f(KC_RCTL);
-    if (code & QK_RSFT) f(KC_RSFT);
-    if (code & QK_RALT) f(KC_RALT);
-    if (code & QK_RGUI) f(KC_RGUI);
-}
-
-static inline void qk_register_weak_mods(uint8_t kc) {
-    add_weak_mods(MOD_BIT(kc));
-    send_keyboard_report();
-}
-
-static inline void qk_unregister_weak_mods(uint8_t kc) {
-    del_weak_mods(MOD_BIT(kc));
-    send_keyboard_report();
-}
-
-static inline void qk_register_mods(uint8_t kc) {
-    add_weak_mods(MOD_BIT(kc));
-    send_keyboard_report();
-}
-
-static inline void qk_unregister_mods(uint8_t kc) {
-    del_weak_mods(MOD_BIT(kc));
-    send_keyboard_report();
+    f(mods_to_send);
 }
 
 void register_code16(uint16_t code) {
     if (IS_MOD(code) || code == KC_NO) {
-        do_code16(code, qk_register_mods);
+        do_code16(code, register_mods);
     } else {
-        do_code16(code, qk_register_weak_mods);
+        do_code16(code, register_weak_mods);
     }
     register_code(code);
 }
@@ -134,9 +118,9 @@ void register_code16(uint16_t code) {
 void unregister_code16(uint16_t code) {
     unregister_code(code);
     if (IS_MOD(code) || code == KC_NO) {
-        do_code16(code, qk_unregister_mods);
+        do_code16(code, unregister_mods);
     } else {
-        do_code16(code, qk_unregister_weak_mods);
+        do_code16(code, unregister_weak_mods);
     }
 }
 

--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -868,9 +868,9 @@ void tap_code(uint8_t code) {
     unregister_code(code);
 }
 
-/** \brief Utilities for actions. (FIXME: Needs better description)
+/** \brief Adds the given physically pressed modifiers and sends a keyboard report immediately.
  *
- * FIXME: Needs documentation.
+ * \param mods A bitfield of modifiers to unregister.
  */
 void register_mods(uint8_t mods) {
     if (mods) {
@@ -879,13 +879,35 @@ void register_mods(uint8_t mods) {
     }
 }
 
-/** \brief Utilities for actions. (FIXME: Needs better description)
+/** \brief Removes the given physically pressed modifiers and sends a keyboard report immediately.
  *
- * FIXME: Needs documentation.
+ * \param mods A bitfield of modifiers to unregister.
  */
 void unregister_mods(uint8_t mods) {
     if (mods) {
         del_mods(mods);
+        send_keyboard_report();
+    }
+}
+
+/** \brief Adds the given weak modifiers and sends a keyboard report immediately.
+ *
+ * \param mods A bitfield of modifiers to register.
+ */
+void register_weak_mods(uint8_t mods) {
+    if (mods) {
+        add_weak_mods(mods);
+        send_keyboard_report();
+    }
+}
+
+/** \brief Removes the given weak modifiers and sends a keyboard report immediately.
+ *
+ * \param mods A bitfield of modifiers to unregister.
+ */
+void unregister_weak_mods(uint8_t mods) {
+    if (mods) {
+        del_weak_mods(mods);
         send_keyboard_report();
     }
 }

--- a/tmk_core/common/action.h
+++ b/tmk_core/common/action.h
@@ -90,6 +90,8 @@ void unregister_code(uint8_t code);
 void tap_code(uint8_t code);
 void register_mods(uint8_t mods);
 void unregister_mods(uint8_t mods);
+void register_weak_mods(uint8_t mods);
+void unregister_weak_mods(uint8_t mods);
 // void set_mods(uint8_t mods);
 void clear_keyboard(void);
 void clear_keyboard_but_mods(void);


### PR DESCRIPTION
This is a "big" bug fix.  It fixes `register_code16` so that it can properly send modded keycodes.  This may impact other parts of the code too, where it wasn't sending things properly.  

