### PR TITLE
Re-init rgb matrix on left half reconnect

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -129,6 +129,9 @@ uint8_t matrix_scan(void) {
         print("left side not responding\n");
       } else {
         print("left side attached\n");
+#ifdef RGB_MATRIX_ENABLE
+        rgb_matrix_init();
+#endif
         ergodox_blink_all_leds();
       }
     }


### PR DESCRIPTION
Reinitializes the RGB Matrix drivers when the left half is reconnected.   This ensures that it is working, on reconnect. 