### PR TITLE
RGB matrix effect - left-right gradient (qmk#7742)

### DIFF
--- a/quantum/rgb_matrix_animations/gradient_left_right_anim.h
+++ b/quantum/rgb_matrix_animations/gradient_left_right_anim.h
@@ -1,0 +1,22 @@
+#ifndef DISABLE_RGB_MATRIX_GRADIENT_LEFT_RIGHT
+RGB_MATRIX_EFFECT(GRADIENT_LEFT_RIGHT)
+#    ifdef RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+
+bool GRADIENT_LEFT_RIGHT(effect_params_t* params) {
+    RGB_MATRIX_USE_LIMITS(led_min, led_max);
+
+    HSV     hsv   = rgb_matrix_config.hsv;
+    uint8_t scale = scale8(64, rgb_matrix_config.speed);
+    for (uint8_t i = led_min; i < led_max; i++) {
+        RGB_MATRIX_TEST_LED_FLAGS();
+        // The x range will be 0..224, map this to 0..7
+        // Relies on hue being 8-bit and wrapping
+        hsv.h   = rgb_matrix_config.hsv.h + (scale * g_led_config.point[i].x >> 5);
+        RGB rgb = hsv_to_rgb(hsv);
+        rgb_matrix_set_color(i, rgb.r, rgb.g, rgb.b);
+    }
+    return led_max < DRIVER_LED_TOTAL;
+}
+
+#    endif  // RGB_MATRIX_CUSTOM_EFFECT_IMPLS
+#endif      // DISABLE_RGB_MATRIX_GRADIENT_LEFT_RIGHT

--- a/quantum/rgb_matrix_animations/rgb_matrix_effects.inc
+++ b/quantum/rgb_matrix_animations/rgb_matrix_effects.inc
@@ -2,6 +2,7 @@
 #include "rgb_matrix_animations/solid_color_anim.h"
 #include "rgb_matrix_animations/alpha_mods_anim.h"
 #include "rgb_matrix_animations/gradient_up_down_anim.h"
+#include "rgb_matrix_animations/gradient_left_right_anim.h"
 #include "rgb_matrix_animations/breathing_anim.h"
 #include "rgb_matrix_animations/colorband_sat_anim.h"
 #include "rgb_matrix_animations/colorband_val_anim.h"


### PR DESCRIPTION
This adds a left to right gradient animation to the rgb matrix feature, to match the existing top to bottom animation. 

Not huge, but ... definitely nice to have. 

Merged upstream Jan 7th