### PR TITLE
Per Key Tap-Hold settings

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -47,6 +47,10 @@ int retro_tapping_counter = 0;
 #    include <fauxclicky.h>
 #endif
 
+#ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
+__attribute__ ((weak)) bool get_ignore_mod_tap_interrupt(uint16_t keycode) { return false; }
+#endif
+
 #ifndef TAP_CODE_DELAY
 #    define TAP_CODE_DELAY 0
 #endif
@@ -308,8 +312,12 @@ void process_action(keyrecord_t *record, action_t action) {
                 default:
                     if (event.pressed) {
                         if (tap_count > 0) {
-#    ifndef IGNORE_MOD_TAP_INTERRUPT
-                            if (record->tap.interrupted) {
+#    if !defined(IGNORE_MOD_TAP_INTERRUPT) || defined(IGNORE_MOD_TAP_INTERRUPT_PER_KEY)
+                            if (
+#        ifdef IGNORE_MOD_TAP_INTERRUPT_PER_KEY
+                                !get_ignore_mod_tap_interrupt(get_event_keycode(record->event)) &&
+#        endif
+                                record->tap.interrupted) {
                                 dprint("mods_tap: tap: cancel: add_mods\n");
                                 // ad hoc: set 0 to cancel tap
                                 record->tap.count = 0;

--- a/tmk_core/common/action_tapping.c
+++ b/tmk_core/common/action_tapping.c
@@ -111,7 +111,7 @@ bool process_tapping(keyrecord_t *keyp) {
                  * This can register the key before settlement of tapping,
                  * useful for long TAPPING_TERM but may prevent fast typing.
                  */
-#    if defined(TAPPING_TERM_PER_KEY) || (!defined(PER_KEY_TAPPING_TERM) && TAPPING_TERM >= 500) || defined(PERMISSIVE_HOLD)
+#    if defined(TAPPING_TERM_PER_KEY) || (TAPPING_TERM >= 500) || defined(PERMISSIVE_HOLD)
 #        ifdef TAPPING_TERM_PER_KEY
                 else if ((get_tapping_term(get_event_keycode(tapping_key.event)) >= 500) && IS_RELEASED(event) && waiting_buffer_typed(event))
 #        else


### PR DESCRIPTION
Adds Per Key implementation of IGNORE_MOD_TAP_INTERRUPT. (qmk#7838)
* Merged upstream Jan 9

Cleanup check for PERMISSIVE_HOLD (qmk#7861)
* Merged upstream Jan 17

Implement and document TAPPING_FORCE_HOLD_PER_KEY (qmk#7859)
* Merged upstream Jan 17 


This may be something we want to implement support for on Oryx. 