### PR TITLE
Ensure setPinInput actually sets input high-Z (#6237)

### DIFF
--- a/quantum/config_common.h
+++ b/quantum/config_common.h
@@ -133,7 +133,7 @@
 #    endif
 
 #    ifndef __ASSEMBLER__
-#        define _PIN_ADDRESS(p, offset) _SFR_IO8(ADDRESS_BASE + (p >> PORT_SHIFTER) + offset)
+#        define _PIN_ADDRESS(p, offset) _SFR_IO8(ADDRESS_BASE + ((p) >> PORT_SHIFTER) + (offset))
 // Port X Input Pins Address
 #        define PINx_ADDRESS(p) _PIN_ADDRESS(p, 0)
 // Port X Data Direction Register,  0:input 1:output

--- a/quantum/quantum.h
+++ b/quantum/quantum.h
@@ -170,7 +170,7 @@ extern layer_state_t layer_state;
 #if defined(__AVR__)
 typedef uint8_t pin_t;
 
-#    define setPinInput(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF))
+#    define setPinInput(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) &= ~_BV((pin)&0xF))
 #    define setPinInputHigh(pin) (DDRx_ADDRESS(pin) &= ~_BV((pin)&0xF), PORTx_ADDRESS(pin) |= _BV((pin)&0xF))
 #    define setPinInputLow(pin) _Static_assert(0, "AVR processors cannot implement an input as pull low")
 #    define setPinOutput(pin) (DDRx_ADDRESS(pin) |= _BV((pin)&0xF))
@@ -180,6 +180,7 @@ typedef uint8_t pin_t;
 #    define writePin(pin, level) ((level) ? writePinHigh(pin) : writePinLow(pin))
 
 #    define readPin(pin) ((bool)(PINx_ADDRESS(pin) & _BV((pin)&0xF)))
+
 #elif defined(PROTOCOL_CHIBIOS)
 typedef ioline_t pin_t;
 


### PR DESCRIPTION
Corrects how `setPinInput` works on AVR to be correct.

Merged upstream Jan 26