### PR TITLE
Dedupe extrakey report struct and send functions in V-USB & LUFA (#7993)

### DIFF
--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -167,11 +167,72 @@ typedef struct {
 } __attribute__((packed)) report_mouse_t;
 
 /* keycode to system usage */
-#define KEYCODE2SYSTEM(key) (key == KC_SYSTEM_POWER ? SYSTEM_POWER_DOWN : (key == KC_SYSTEM_SLEEP ? SYSTEM_SLEEP : (key == KC_SYSTEM_WAKE ? SYSTEM_WAKE_UP : 0)))
+static inline uint16_t KEYCODE2SYSTEM(uint8_t key) {
+    switch (key) {
+        case KC_SYSTEM_POWER:
+            return SYSTEM_POWER_DOWN;
+        case KC_SYSTEM_SLEEP:
+            return SYSTEM_SLEEP;
+        case KC_SYSTEM_WAKE:
+            return SYSTEM_WAKE_UP;
+        default:
+            return 0;
+    }
+}
 
 /* keycode to consumer usage */
-#define KEYCODE2CONSUMER(key) \
-    (key == KC_AUDIO_MUTE ? AUDIO_MUTE : (key == KC_AUDIO_VOL_UP ? AUDIO_VOL_UP : (key == KC_AUDIO_VOL_DOWN ? AUDIO_VOL_DOWN : (key == KC_MEDIA_NEXT_TRACK ? TRANSPORT_NEXT_TRACK : (key == KC_MEDIA_PREV_TRACK ? TRANSPORT_PREV_TRACK : (key == KC_MEDIA_FAST_FORWARD ? TRANSPORT_FAST_FORWARD : (key == KC_MEDIA_REWIND ? TRANSPORT_REWIND : (key == KC_MEDIA_STOP ? TRANSPORT_STOP : (key == KC_MEDIA_EJECT ? TRANSPORT_STOP_EJECT : (key == KC_MEDIA_PLAY_PAUSE ? TRANSPORT_PLAY_PAUSE : (key == KC_MEDIA_SELECT ? AL_CC_CONFIG : (key == KC_MAIL ? AL_EMAIL : (key == KC_CALCULATOR ? AL_CALCULATOR : (key == KC_MY_COMPUTER ? AL_LOCAL_BROWSER : (key == KC_WWW_SEARCH ? AC_SEARCH : (key == KC_WWW_HOME ? AC_HOME : (key == KC_WWW_BACK ? AC_BACK : (key == KC_WWW_FORWARD ? AC_FORWARD : (key == KC_WWW_STOP ? AC_STOP : (key == KC_WWW_REFRESH ? AC_REFRESH : (key == KC_BRIGHTNESS_UP ? BRIGHTNESS_UP : (key == KC_BRIGHTNESS_DOWN ? BRIGHTNESS_DOWN : (key == KC_WWW_FAVORITES ? AC_BOOKMARKS : 0)))))))))))))))))))))))
+static inline uint16_t KEYCODE2CONSUMER(uint8_t key) {
+    switch (key) {
+        case KC_AUDIO_MUTE:
+            return AUDIO_MUTE;
+        case KC_AUDIO_VOL_UP:
+            return AUDIO_VOL_UP;
+        case KC_AUDIO_VOL_DOWN:
+            return AUDIO_VOL_DOWN;
+        case KC_MEDIA_NEXT_TRACK:
+            return TRANSPORT_NEXT_TRACK;
+        case KC_MEDIA_PREV_TRACK:
+            return TRANSPORT_PREV_TRACK;
+        case KC_MEDIA_FAST_FORWARD:
+            return TRANSPORT_FAST_FORWARD;
+        case KC_MEDIA_REWIND:
+            return TRANSPORT_REWIND;
+        case KC_MEDIA_STOP:
+            return TRANSPORT_STOP;
+        case KC_MEDIA_EJECT:
+            return TRANSPORT_STOP_EJECT;
+        case KC_MEDIA_PLAY_PAUSE:
+            return TRANSPORT_PLAY_PAUSE;
+        case KC_MEDIA_SELECT:
+            return AL_CC_CONFIG;
+        case KC_MAIL:
+            return AL_EMAIL;
+        case KC_CALCULATOR:
+            return AL_CALCULATOR;
+        case KC_MY_COMPUTER:
+            return AL_LOCAL_BROWSER;
+        case KC_WWW_SEARCH:
+            return AC_SEARCH;
+        case KC_WWW_HOME:
+            return AC_HOME;
+        case KC_WWW_BACK:
+            return AC_BACK;
+        case KC_WWW_FORWARD:
+            return AC_FORWARD;
+        case KC_WWW_STOP:
+            return AC_STOP;
+        case KC_WWW_REFRESH:
+            return AC_REFRESH;
+        case KC_BRIGHTNESS_UP:
+            return BRIGHTNESS_UP;
+        case KC_BRIGHTNESS_DOWN:
+            return BRIGHTNESS_DOWN;
+        case KC_WWW_FAVORITES:
+            return AC_BOOKMARKS;
+        default:
+            return 0;
+    }
+}
 
 uint8_t has_anykey(report_keyboard_t* keyboard_report);
 uint8_t get_first_key(report_keyboard_t* keyboard_report);

--- a/tmk_core/common/report.h
+++ b/tmk_core/common/report.h
@@ -151,6 +151,11 @@ typedef union {
 } __attribute__((packed)) report_keyboard_t;
 
 typedef struct {
+    uint8_t  report_id;
+    uint16_t usage;
+} __attribute__((packed)) report_extra_t;
+
+typedef struct {
 #ifdef MOUSE_SHARED_EP
     uint8_t report_id;
 #endif

--- a/tmk_core/protocol/arm_atsam/main_arm_atsam.c
+++ b/tmk_core/protocol/arm_atsam/main_arm_atsam.c
@@ -131,7 +131,7 @@ void send_extra(uint8_t report_id, uint16_t data) {
 void send_system(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
     if (data != 0) data = data - SYSTEM_POWER_DOWN + 1;
-    send_extra(REPORT_ID_SYSTEM,  data);
+    send_extra(REPORT_ID_SYSTEM, data);
 #endif  // EXTRAKEY_ENABLE
 }
 

--- a/tmk_core/protocol/arm_atsam/main_arm_atsam.c
+++ b/tmk_core/protocol/arm_atsam/main_arm_atsam.c
@@ -110,40 +110,34 @@ void send_mouse(report_mouse_t *report) {
 #endif  // MOUSEKEY_ENABLE
 }
 
-void send_system(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
+void send_extra(uint8_t report_id, uint16_t data) {
     uint32_t irqflags;
 
     irqflags = __get_PRIMASK();
     __disable_irq();
     __DMB();
 
-    udi_hid_exk_report.desc.report_id = REPORT_ID_SYSTEM;
-    if (data != 0) data = data - SYSTEM_POWER_DOWN + 1;
+    udi_hid_exk_report.desc.report_id   = report_id;
     udi_hid_exk_report.desc.report_data = data;
     udi_hid_exk_b_report_valid          = 1;
     udi_hid_exk_send_report();
 
     __DMB();
     __set_PRIMASK(irqflags);
+}
+#endif  // EXTRAKEY_ENABLE
+
+void send_system(uint16_t data) {
+#ifdef EXTRAKEY_ENABLE
+    if (data != 0) data = data - SYSTEM_POWER_DOWN + 1;
+    send_extra(REPORT_ID_SYSTEM,  data);
 #endif  // EXTRAKEY_ENABLE
 }
 
 void send_consumer(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
-    uint32_t irqflags;
-
-    irqflags = __get_PRIMASK();
-    __disable_irq();
-    __DMB();
-
-    udi_hid_exk_report.desc.report_id   = REPORT_ID_CONSUMER;
-    udi_hid_exk_report.desc.report_data = data;
-    udi_hid_exk_b_report_valid          = 1;
-    udi_hid_exk_send_report();
-
-    __DMB();
-    __set_PRIMASK(irqflags);
+    send_extra(REPORT_ID_CONSUMER, data);
 #endif  // EXTRAKEY_ENABLE
 }
 

--- a/tmk_core/protocol/chibios/usb_main.h
+++ b/tmk_core/protocol/chibios/usb_main.h
@@ -72,20 +72,6 @@ void mouse_in_cb(USBDriver *usbp, usbep_t ep);
 /* shared IN request callback handler */
 void shared_in_cb(USBDriver *usbp, usbep_t ep);
 
-/* ---------------
- * Extrakey header
- * ---------------
- */
-
-#ifdef EXTRAKEY_ENABLE
-
-/* extra report structure */
-typedef struct {
-    uint8_t  report_id;
-    uint16_t usage;
-} __attribute__((packed)) report_extra_t;
-#endif /* EXTRAKEY_ENABLE */
-
 /* --------------
  * Console header
  * --------------

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -814,7 +814,7 @@ static void send_system(uint16_t data) {
  */
 static void send_consumer(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
-    uint8_t where   = where_to_send();
+    uint8_t where = where_to_send();
 
 #    ifdef BLUETOOTH_ENABLE
     if (where == OUTPUT_BLUETOOTH || where == OUTPUT_USB_AND_BT) {

--- a/tmk_core/protocol/lufa/lufa.c
+++ b/tmk_core/protocol/lufa/lufa.c
@@ -776,17 +776,17 @@ static void send_mouse(report_mouse_t *report) {
 #endif
 }
 
-/** \brief Send System
+/** \brief Send Extra
  *
  * FIXME: Needs doc
  */
-static void send_system(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
+static void send_extra(uint8_t report_id, uint16_t data) {
     uint8_t timeout = 255;
 
     if (USB_DeviceState != DEVICE_STATE_Configured) return;
 
-    report_extra_t r = {.report_id = REPORT_ID_SYSTEM, .usage = data - SYSTEM_POWER_DOWN + 1};
+    report_extra_t r = {.report_id = report_id, .usage = data};
     Endpoint_SelectEndpoint(SHARED_IN_EPNUM);
 
     /* Check if write ready for a polling interval around 10ms */
@@ -795,6 +795,16 @@ static void send_system(uint16_t data) {
 
     Endpoint_Write_Stream_LE(&r, sizeof(report_extra_t), NULL);
     Endpoint_ClearIN();
+}
+#endif
+
+/** \brief Send System
+ *
+ * FIXME: Needs doc
+ */
+static void send_system(uint16_t data) {
+#ifdef EXTRAKEY_ENABLE
+    send_extra(REPORT_ID_SYSTEM, data - SYSTEM_POWER_DOWN + 1);
 #endif
 }
 
@@ -804,7 +814,6 @@ static void send_system(uint16_t data) {
  */
 static void send_consumer(uint16_t data) {
 #ifdef EXTRAKEY_ENABLE
-    uint8_t timeout = 255;
     uint8_t where   = where_to_send();
 
 #    ifdef BLUETOOTH_ENABLE
@@ -843,15 +852,7 @@ static void send_consumer(uint16_t data) {
         return;
     }
 
-    report_extra_t r = {.report_id = REPORT_ID_CONSUMER, .usage = data};
-    Endpoint_SelectEndpoint(SHARED_IN_EPNUM);
-
-    /* Check if write ready for a polling interval around 10ms */
-    while (timeout-- && !Endpoint_IsReadWriteAllowed()) _delay_us(40);
-    if (!Endpoint_IsReadWriteAllowed()) return;
-
-    Endpoint_Write_Stream_LE(&r, sizeof(report_extra_t), NULL);
-    Endpoint_ClearIN();
+    send_extra(REPORT_ID_CONSUMER, data);
 #endif
 }
 

--- a/tmk_core/protocol/lufa/lufa.h
+++ b/tmk_core/protocol/lufa/lufa.h
@@ -58,12 +58,6 @@ extern host_driver_t lufa_driver;
 }
 #endif
 
-/* extra report structure */
-typedef struct {
-    uint8_t  report_id;
-    uint16_t usage;
-} __attribute__((packed)) report_extra_t;
-
 #ifdef API_ENABLE
 #    include "api.h"
 #endif

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -114,10 +114,10 @@ static void send_mouse(report_mouse_t *report) {
 }
 
 static void send_extra(uint8_t report_id, uint16_t data) {
-    static uint8_t last_id    = 0;
+    static uint8_t  last_id   = 0;
     static uint16_t last_data = 0;
     if ((report_id == last_id) && (data == last_data)) return;
-    last_id = report_id;
+    last_id   = report_id;
     last_data = data;
 
     report_extra_t report = {.report_id = report_id, .usage = data};
@@ -126,13 +126,9 @@ static void send_extra(uint8_t report_id, uint16_t data) {
     }
 }
 
-static void send_system(uint16_t data) {
-    send_extra(REPORT_ID_SYSTEM, data);
-}
+static void send_system(uint16_t data) { send_extra(REPORT_ID_SYSTEM, data); }
 
-static void send_consumer(uint16_t data) {
-    send_extra(REPORT_ID_CONSUMER, data);
-}
+static void send_consumer(uint16_t data) { send_extra(REPORT_ID_CONSUMER, data); }
 
 /*------------------------------------------------------------------*
  * Request from host                                                *

--- a/tmk_core/protocol/vusb/vusb.c
+++ b/tmk_core/protocol/vusb/vusb.c
@@ -113,31 +113,25 @@ static void send_mouse(report_mouse_t *report) {
     }
 }
 
-typedef struct {
-    uint8_t  report_id;
-    uint16_t usage;
-} __attribute__((packed)) report_extra_t;
-
-static void send_system(uint16_t data) {
+static void send_extra(uint8_t report_id, uint16_t data) {
+    static uint8_t last_id    = 0;
     static uint16_t last_data = 0;
-    if (data == last_data) return;
+    if ((report_id == last_id) && (data == last_data)) return;
+    last_id = report_id;
     last_data = data;
 
-    report_extra_t report = {.report_id = REPORT_ID_SYSTEM, .usage = data};
+    report_extra_t report = {.report_id = report_id, .usage = data};
     if (usbInterruptIsReady3()) {
         usbSetInterrupt3((void *)&report, sizeof(report));
     }
 }
 
-static void send_consumer(uint16_t data) {
-    static uint16_t last_data = 0;
-    if (data == last_data) return;
-    last_data = data;
+static void send_system(uint16_t data) {
+    send_extra(REPORT_ID_SYSTEM, data);
+}
 
-    report_extra_t report = {.report_id = REPORT_ID_CONSUMER, .usage = data};
-    if (usbInterruptIsReady3()) {
-        usbSetInterrupt3((void *)&report, sizeof(report));
-    }
+static void send_consumer(uint16_t data) {
+    send_extra(REPORT_ID_CONSUMER, data);
 }
 
 /*------------------------------------------------------------------*


### PR DESCRIPTION
Unifies the EXTRAKEYS report structure. 
Merged upstream on Feb 2

Use function for `KEYCODE2xxx` routines instead of macro. (qmk#8101)
Merged upstream on  Feb 3