### PR TITLE
Compile error if ONESHOT_TIMEOUT defined but oneshot disabled (#8100)

### DIFF
--- a/tmk_core/common/action.c
+++ b/tmk_core/common/action.c
@@ -86,13 +86,15 @@ void action_exec(keyevent_t event) {
 
     keyrecord_t record = {.event = event};
 
-#if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
+#ifndef NO_ACTION_ONESHOT
+#    if (defined(ONESHOT_TIMEOUT) && (ONESHOT_TIMEOUT > 0))
     if (has_oneshot_layer_timed_out()) {
         clear_oneshot_layer_state(ONESHOT_OTHER_KEY_PRESSED);
     }
     if (has_oneshot_mods_timed_out()) {
         clear_oneshot_mods();
     }
+#    endif
 #endif
 
 #ifndef NO_ACTION_TAPPING


### PR DESCRIPTION
If ONESHOT_TIMEOUT is defined but oneshot disabled, then it will cause a compiler error. 

Merged upstream on Feb 9th 