### PR TITLE
Fix out of bound OLED font access (#8145)

### DIFF
--- a/drivers/oled/oled_driver.c
+++ b/drivers/oled/oled_driver.c
@@ -392,6 +392,8 @@ void oled_write_char(const char data, bool invert) {
     static uint8_t oled_temp_buffer[OLED_FONT_WIDTH];
     memcpy(&oled_temp_buffer, oled_cursor, OLED_FONT_WIDTH);
 
+    _Static_assert(sizeof(font) >= ((OLED_FONT_END + 1 - OLED_FONT_START) * OLED_FONT_WIDTH), "OLED_FONT_END references outside array");
+
     // set the reder buffer data
     uint8_t cast_data = (uint8_t)data;  // font based on unsigned type for index
     if (cast_data < OLED_FONT_START || cast_data > OLED_FONT_END) {

--- a/drivers/oled/oled_driver.h
+++ b/drivers/oled/oled_driver.h
@@ -131,7 +131,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 // unsigned char value of the last character in the font file
 #if !defined(OLED_FONT_END)
-#    define OLED_FONT_END 224
+#    define OLED_FONT_END 223
 #endif
 // Font render width
 #if !defined(OLED_FONT_WIDTH)


### PR DESCRIPTION
* Fix out of bound OLED font access

The default font is 1344 bytes, or a total of 224 glyphs (each 6-bytes wide).
OLED_FONT_END defaults to 224, which if used will then index off the end of
the font array. So either the documentation or code is wrong.

Instead of figuring out the rewording of the documentation, just change
the OLED_FONT_END default value to 223, to match the documentation and code.

Merged upstream on Feb 11