### PR TITLE
[Keyboard] Remove i2c write command when reading columns on Ergodox EZ

### DIFF
--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -216,10 +216,8 @@ static matrix_row_t read_cols(uint8_t row) {
       return 0;
     } else {
       uint8_t data    = 0;
-      mcp23018_status = i2c_start(I2C_ADDR_WRITE, ERGODOX_EZ_I2C_TIMEOUT);
-      if (mcp23018_status) goto out;
-      mcp23018_status = i2c_write(GPIOB, ERGODOX_EZ_I2C_TIMEOUT);
-      if (mcp23018_status) goto out;
+      // reading GPIOB (column port) since in mcp23018's sequential mode
+      // it is addressed directly after writing to GPIOA in select_row()
       mcp23018_status = i2c_start(I2C_ADDR_READ, ERGODOX_EZ_I2C_TIMEOUT);
       if (mcp23018_status) goto out;
       mcp23018_status = i2c_read_nack(ERGODOX_EZ_I2C_TIMEOUT);


### PR DESCRIPTION
 (#8092)
* Remove i2c write command when reading cols on Ergodox EZ
* Comment on mcp23018 address state during read_cols


Fixes an "out of spec" issue, and should boost matrix scan speed. 