### PR TITLE
Fixes for Moonlander

### DIFF
--- a/keyboards/moonlander/keymaps/default/keymap.c
+++ b/keyboards/moonlander/keymaps/default/keymap.c
@@ -49,7 +49,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                             RGB_HUD, RGB_VAD, RGB_HUI, TOGGLE_LAYER_COLOR,KC_TRNS, KC_TRNS
     ),
 
-    [1] = LAYOUT_moonlander(
+    [MDIA] = LAYOUT_moonlander(
         KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_TRNS, KC_MS_U, KC_TRNS, KC_TRNS, KC_TRNS,           KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS,
         KC_TRNS, KC_TRNS, KC_MS_L, KC_MS_D, KC_MS_R, KC_TRNS, KC_TRNS,           KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_TRNS, KC_MPLY,

--- a/keyboards/moonlander/matrix.c
+++ b/keyboards/moonlander/matrix.c
@@ -64,7 +64,6 @@ uint8_t mcp23018_rx[1];
 
 void mcp23018_init(void) {
     i2c_init();
-    i2c_start(MCP23018_DEFAULT_ADDRESS << 1);
 
     // #define MCP23_ROW_PINS { GPB5, GBP4, GBP3, GBP2, GBP1, GBP0 }       outputs
     // #define MCP23_COL_PINS { GPA0, GBA1, GBA2, GBA3, GBA4, GBA5, GBA6 } inputs


### PR DESCRIPTION
Removed i2c_start, as it's no longer needed and causes deadlocks now.  Also fixed numbering of default keymap.