### PR TITLE
Revert "[Keyboard] Remove i2c write command when reading columns on Ergodox EZ"

### DIFF
--- a/keyboards/ergodox_ez/config.h
+++ b/keyboards/ergodox_ez/config.h
@@ -106,7 +106,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * manufacturer specs.
  */
 
-#define DEBOUNCE 60
+#define DEBOUNCE 30
 
 #define USB_MAX_POWER_CONSUMPTION 500
 

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -216,8 +216,10 @@ static matrix_row_t read_cols(uint8_t row) {
       return 0;
     } else {
       uint8_t data    = 0;
-      // reading GPIOB (column port) since in mcp23018's sequential mode
-      // it is addressed directly after writing to GPIOA in select_row()
+      mcp23018_status = i2c_start(I2C_ADDR_WRITE, ERGODOX_EZ_I2C_TIMEOUT);
+      if (mcp23018_status) goto out;
+      mcp23018_status = i2c_write(GPIOB, ERGODOX_EZ_I2C_TIMEOUT);
+      if (mcp23018_status) goto out;
       mcp23018_status = i2c_start(I2C_ADDR_READ, ERGODOX_EZ_I2C_TIMEOUT);
       if (mcp23018_status) goto out;
       mcp23018_status = i2c_read_nack(ERGODOX_EZ_I2C_TIMEOUT);


### PR DESCRIPTION
Reverts zsa/qmk_firmware#285

While this improves the matrix scan speed and is more compliant with datasheets, it's causing issues with debouncing being effective. 
