### PR TITLE
Enable LED Feedback for Dynamic Macro recording

### DIFF
--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -25,6 +25,19 @@ keyboard_config_t keyboard_config;
 bool mcp23018_leds[3] = {0, 0, 0};
 bool is_launching = false;
 
+#ifdef DYNAMIC_MACRO_ENABLE
+static bool is_dynamic_recording = false;
+
+void dynamic_macro_record_start_user(void) {
+    is_dynamic_recording = true;
+}
+
+void dynamic_macro_record_end_user(int8_t direction) {
+    is_dynamic_recording = false;
+    ML_LED_3(false);
+}
+#endif
+
 void moonlander_led_task(void) {
     if (is_launching) {
         ML_LED_1(false);
@@ -61,6 +74,14 @@ void moonlander_led_task(void) {
         is_launching = false;
         layer_state_set_kb(layer_state);
     }
+#ifdef DYNAMIC_MACRO_ENABLE
+    else if (is_dynamic_recording) {
+        ML_LED_3(true);
+        wait_ms(100);
+        ML_LED_3(false);
+        wait_ms(155);
+    }
+#endif
 #ifdef WEBUSB_ENABLE
     else if (webusb_state.pairing == true) {
         static uint8_t led_mask;
@@ -107,6 +128,7 @@ void moonlander_led_task(void) {
         wait_ms(150);
     }
 #endif
+
 }
 
 static THD_WORKING_AREA(waLEDThread, 128);

--- a/keyboards/planck/ez/ez.c
+++ b/keyboards/planck/ez/ez.c
@@ -328,8 +328,26 @@ bool music_mask_kb(uint16_t keycode) {
 #ifdef ORYX_ENABLE
 static uint16_t loops = 0;
 static bool is_on = false;
+#endif
+
+#ifdef DYNAMIC_MACRO_ENABLE
+static bool is_dynamic_recording = false;
+static uint16_t dynamic_loop_timer;
+
+void dynamic_macro_record_start_user(void) {
+    is_dynamic_recording = true;
+    dynamic_loop_timer = timer_read();
+    planck_ez_left_led_on();
+}
+
+void dynamic_macro_record_end_user(int8_t direction) {
+    is_dynamic_recording = false;
+    layer_state_set_kb(layer_state);
+}
+#endif
 
 void matrix_scan_kb(void) {
+#ifdef ORYX_ENABLE
     if(webusb_state.pairing == true) {
         if(loops == 0) {
           //lights off
@@ -358,5 +376,22 @@ void matrix_scan_kb(void) {
       planck_ez_left_led_off();
       planck_ez_right_led_off();
     }
-}
 #endif
+#ifdef DYNAMIC_MACRO_ENABLE
+    if (is_dynamic_recording) {
+        if (timer_elapsed(dynamic_loop_timer) > 1)
+        {
+            static uint8_t counter;
+            counter++;
+            if (counter > 100) {
+                planck_ez_left_led_on();
+            } else {
+                planck_ez_left_led_off();
+
+            }
+            dynamic_loop_timer = timer_read();
+        }
+    }
+#endif
+    matrix_scan_user();
+}


### PR DESCRIPTION
Enables a blinking LED when Dynamic Macros are enabled. 
Where applicable, the red LED will blink when recording a macro, and stop when it's finished. 
For the Planck EZ, the left LED blinks (since there is no color option here). 