### PR TITLE
fix: layer3 indicator leds

### DIFF
--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -184,6 +184,7 @@ layer_state_t layer_state_set_kb(layer_state_t state) {
             break;
         case 3:
             ML_LED_3(1);
+            ML_LED_6(1);
             break;
         case 4:
             ML_LED_4(1);


### PR DESCRIPTION
For layer 1 & 2, the led indicators are on on both side, this adds the same behavior for layer 3