### PR TITLE
Add macro for defining LED layouts on ergodox_ez glow

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -288,3 +288,25 @@ extern keyboard_config_t keyboard_config;
     { R05, R15, R25, R35, R45, R55 },     \
     { R06, R16, R26, R36, R46, KC_NO }    \
     }
+
+/*  ---- LEFT HAND ----     ---- RIGHT HAND ---- */
+#define LED_LAYOUT_ergodox_pretty(                \
+    L01,L02,L03,L04,L05,    R01,R02,R03,R04,R05,  \
+    L11,L12,L13,L14,L15,    R11,R12,R13,R14,R15,  \
+    L21,L22,L23,L24,L25,    R21,R22,R23,R24,R25,  \
+    L31,L32,L33,L34,L35,    R31,R32,R33,R34,R35,  \
+    L41,L42,L43,L44,            R42,R43,R44,R45 ) \
+                                                  \
+   /* matrix positions */                         \
+    { R01, R02, R03, R04, R05,                    \
+      R11, R12, R13, R14, R15,                    \
+      R21, R22, R23, R24, R25,                    \
+      R31, R32, R33, R34, R35,                    \
+           R42, R43, R44, R45,                    \
+                                                  \
+      L05, L04, L03, L02, L01,                    \
+      L15, L14, L13, L12, L11,                    \
+      L25, L24, L23, L22, L21,                    \
+      L35, L34, L33, L32, L31,                    \
+           L44, L43, L42, L41                     \
+    }


### PR DESCRIPTION
While working on a custom layout for my EZ Glow I didn't see a way to visually identify LED colors per-key using an array-per-layer so I created a macro in `glow.h` based on the keymap macros. Of note the visual map only includes the keys with LEDs and so it doesn't match the layout alignments/visuals.

If there's interest in merging this PR I can recreate the other layout macros in similar fashion for the LEDs, the `_80`, `_pretty_80`, and un-suffixed versions. Also I'm happy to do any other work necessary to prep this PR.

**Config Before**

```c
const uint8_t PROGMEM ledmap[][DRIVER_LED_TOTAL][1] = {
    /* Key map is reversed for left hand
      6     7     8     9     0
      Y     U     I     O     P
      H     J     K     L     ;
      N     M     ,     .     /
            UP    DN    [     ]

      5     4     3     2     1
      T     R     E     W     Q
      G     F     D     S     A
      B     V     C     X     Z
            RGT   LFT   ORYX  "
     */
     [0] = {
       ___,  ___,  ___,  ___,  ___,
       _RED, _BLU, _BLU, _BLU, _YLW,
       _RED, _BLU, _BLU, _BLU, _YLW,
       _YLW, _BLU, _BLU, _BLU, _YLW,
             _BLU, _BLU, _YLW, _YLW,

       ___,  ___,  ___,  ___,  ___,
       ___,  _RED, _RED, _BLU, ___,
       ___,  _YLW, _YLW, ___,  _BLU,
       ___,  _GRN, _GRN, ___,  _BLU,
             ___,  ___,  ___,  ___
     }
};
```

**Config After**

```c
const uint8_t PROGMEM ledmap[][DRIVER_LED_TOTAL][1] = {
    [0] = LED_LAYOUT_ergodox_pretty(
      ___,  ___,  ___,  ___,  ___,        ___,  ___,  ___,  ___,  ___,
      ___,  _BLU, _RED, _RED, ___,        _RED, _BLU, _BLU, _BLU, _YLW,
      _BLU, ___,  _YLW, _YLW, ___,        _RED, _BLU, _BLU, _BLU, _YLW,
      _BLU, ___,  _GRN, _GRN, ___,        _YLW, _BLU, _BLU, _BLU, _YLW,
      ___,  ___,  ___,  ___,                    _BLU, _BLU, _YLW, _YLW
    )
}
```