### PR TITLE
Adds caps lock led status on Moonlander/Ergodox

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -470,5 +470,18 @@ void matrix_scan_kb(void) {
     }
 #endif
 
+#ifdef CAPS_LOCK_STATUS
+    led_t led_state = host_keyboard_led_state();
+    if(led_state.caps_lock) {
+        ergodox_right_led_1_on();
+    }
+    else {
+        uint8_t layer = get_highest_layer(layer_state);
+        if(layer != 1) {
+        ergodox_right_led_1_off();
+        }
+    }
+#endif
+
     matrix_scan_user();
 }

--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -473,12 +473,12 @@ void matrix_scan_kb(void) {
 #ifdef CAPS_LOCK_STATUS
     led_t led_state = host_keyboard_led_state();
     if(led_state.caps_lock) {
-        ergodox_right_led_1_on();
+        ergodox_right_led_3_on();
     }
     else {
         uint8_t layer = get_highest_layer(layer_state);
         if(layer != 1) {
-        ergodox_right_led_1_off();
+        ergodox_right_led_3_off();
         }
     }
 #endif

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -132,12 +132,12 @@ void moonlander_led_task(void) {
     else {
         led_t led_state = host_keyboard_led_state();
         if(led_state.caps_lock) {
-            ML_LED_1(true);
+            ML_LED_6(true);
         }
         else {
             uint8_t layer = get_highest_layer(layer_state);
             if(layer != 1) {
-                ML_LED_1(false);
+                ML_LED_6(false);
             }
         }
     }

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -374,7 +374,7 @@ bool music_mask_kb(uint16_t keycode) {
         case QK_LAYER_TAP_TOGGLE ... QK_LAYER_MOD_MAX:
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:
         case AU_ON ... MUV_DE:
-        case RESET:Caps lock state
+        case RESET:
         case EEP_RST:
             return false;
         default:

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -128,7 +128,20 @@ void moonlander_led_task(void) {
         wait_ms(150);
     }
 #endif
-
+#ifdef CAPS_LOCK_STATUS
+    else {
+        led_t led_state = host_keyboard_led_state();
+        if(led_state.caps_lock) {
+            ML_LED_1(true);
+        }
+        else {
+            uint8_t layer = get_highest_layer(layer_state);
+            if(layer != 1) {
+                ML_LED_1(false);
+            }
+        }
+    }
+#endif
 }
 
 static THD_WORKING_AREA(waLEDThread, 128);
@@ -361,7 +374,7 @@ bool music_mask_kb(uint16_t keycode) {
         case QK_LAYER_TAP_TOGGLE ... QK_LAYER_MOD_MAX:
         case QK_MOD_TAP ... QK_MOD_TAP_MAX:
         case AU_ON ... MUV_DE:
-        case RESET:
+        case RESET:Caps lock state
         case EEP_RST:
             return false;
         default:


### PR DESCRIPTION
The goal of this PR is to display the Caps lock status on the most left led of the Moonlander and Ergodox by setting a config flag `CAPS_LOCK_STATUS` 