### PR TITLE
Add LEADER_NO_TIMEOUT support

### DIFF
--- a/quantum/process_keycode/process_leader.c
+++ b/quantum/process_keycode/process_leader.c
@@ -49,7 +49,10 @@ bool process_leader(uint16_t keycode, keyrecord_t *record) {
     // Leader key set-up
     if (record->event.pressed) {
         if (leading) {
-            if (timer_elapsed(leader_time) < LEADER_TIMEOUT) {
+#    ifndef LEADER_NO_TIMEOUT
+            if (timer_elapsed(leader_time) < LEADER_TIMEOUT)
+#    endif  // LEADER_NO_TIMEOUT
+            {
 #    ifndef LEADER_KEY_STRICT_KEY_PROCESSING
                 if ((keycode >= QK_MOD_TAP && keycode <= QK_MOD_TAP_MAX) || (keycode >= QK_LAYER_TAP && keycode <= QK_LAYER_TAP_MAX)) {
                     keycode = keycode & 0xFF;

--- a/quantum/process_keycode/process_leader.h
+++ b/quantum/process_keycode/process_leader.h
@@ -35,4 +35,9 @@ void qk_leader_start(void);
     extern uint16_t leader_time;        \
     extern uint16_t leader_sequence[5]; \
     extern uint8_t  leader_sequence_size
-#define LEADER_DICTIONARY() if (leading && timer_elapsed(leader_time) > LEADER_TIMEOUT)
+
+#ifdef LEADER_NO_TIMEOUT
+#    define LEADER_DICTIONARY() if (leading && leader_sequence_size > 0 && timer_elapsed(leader_time) > LEADER_TIMEOUT)
+#else
+#    define LEADER_DICTIONARY() if (leading && timer_elapsed(leader_time) > LEADER_TIMEOUT)
+#endif


### PR DESCRIPTION
Simply ported from QMK main repo, works on Moonlander MK I.

Ref: [QMK-Infinite Leader key timeout](https://beta.docs.qmk.fm/using-qmk/advanced-keycodes/feature_leader_key#infinite-leader-key-timeout)