### PR TITLE
Fix bug in caps lock light logic for Moonlander

### DIFF
--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -137,7 +137,7 @@ void moonlander_led_task(void) {
         }
         else {
             uint8_t layer = get_highest_layer(layer_state);
-            if(layer != 1) {
+            if(layer != 3 && layer != 6) {
                 ML_LED_6(false);
             }
         }

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -208,11 +208,6 @@ layer_state_t layer_state_set_kb(layer_state_t state) {
     if(led_state.caps_lock) {
         LED_6 = true;
     }
-    else {
-        if(layer != 3 && layer != 6) {
-            LED_6 = false;
-        }
-    }
 #endif
 
     ML_LED_1(LED_1);

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -188,7 +188,9 @@ layer_state_t layer_state_set_kb(layer_state_t state) {
             break;
         case 3:
             LED_3 = true;
+#if !defined(CAPS_LOCK_STATUS)
             LED_6 = true;
+#endif
             break;
         case 4:
             LED_4 = true;

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -129,7 +129,7 @@ void moonlander_led_task(void) {
         wait_ms(150);
     }
 #endif
-#if !defined(MOONLANDER_USER_LEDS) && defined(CAPS_LOCK_STATUS)
+#if !defined(MOONLANDER_USER_LEDS)
     else {
         layer_state_set_kb(layer_state);
     }
@@ -206,13 +206,6 @@ layer_state_t layer_state_set_kb(layer_state_t state) {
         default:
             break;
     }
-
-#ifdef CAPS_LOCK_STATUS
-    led_t led_state = host_keyboard_led_state();
-    if(led_state.caps_lock) {
-        LED_6 = true;
-    }
-#endif
 
     ML_LED_1(LED_1);
     ML_LED_2(LED_2);
@@ -420,6 +413,16 @@ const uint8_t music_map[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_moonlander(
                      0,  1,  2,     5,  6,  7
 );
 // clang-format on
+#endif
+
+#ifdef CAPS_LOCK_STATUS
+bool led_update_kb(led_t led_state) {
+    bool res = led_update_user(led_state);
+    if(res) {
+        ML_LED_6(led_state.caps_lock);
+    }
+    return res;
+}
 #endif
 
 bool process_record_kb(uint16_t keycode, keyrecord_t *record) {

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -197,7 +197,9 @@ layer_state_t layer_state_set_kb(layer_state_t state) {
             LED_5 = true;
             break;
         case 6:
+#if !defined(CAPS_LOCK_STATUS)
             LED_6 = true;
+#endif
             break;
         default:
             break;

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -212,7 +212,9 @@ layer_state_t layer_state_set_kb(layer_state_t state) {
     ML_LED_3(LED_3);
     ML_LED_4(LED_4);
     ML_LED_5(LED_5);
+#if !defined(CAPS_LOCK_STATUS)
     ML_LED_6(LED_6);
+#endif
 
     return state;
 }

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -129,18 +129,9 @@ void moonlander_led_task(void) {
         wait_ms(150);
     }
 #endif
-#ifdef CAPS_LOCK_STATUS
+#if !defined(MOONLANDER_USER_LEDS) && defined(CAPS_LOCK_STATUS)
     else {
-        led_t led_state = host_keyboard_led_state();
-        if(led_state.caps_lock) {
-            ML_LED_6(true);
-        }
-        else {
-            uint8_t layer = get_highest_layer(layer_state);
-            if(layer != 3 && layer != 6) {
-                ML_LED_6(false);
-            }
-        }
+        layer_state_set_kb(layer_state);
     }
 #endif
 }
@@ -178,40 +169,58 @@ void keyboard_pre_init_kb(void) {
 layer_state_t layer_state_set_kb(layer_state_t state) {
     state = layer_state_set_user(state);
     if (is_launching || !keyboard_config.led_level) return state;
-
-    ML_LED_1(false);
-    ML_LED_2(false);
-    ML_LED_3(false);
-    ML_LED_4(false);
-    ML_LED_5(false);
-    ML_LED_6(false);
-
+    bool LED_1 = false;
+    bool LED_2 = false;
+    bool LED_3 = false;
+    bool LED_4 = false;
+    bool LED_5 = false;
+    bool LED_6 = false;
+    
     uint8_t layer = get_highest_layer(state);
     switch (layer) {
         case 1:
-            ML_LED_1(1);
-            ML_LED_4(1);
+            LED_1 = true;
+            LED_4 = true;
             break;
         case 2:
-            ML_LED_2(1);
-            ML_LED_5(1);
+            LED_2 = true;
+            LED_5 = true;
             break;
         case 3:
-            ML_LED_3(1);
-            ML_LED_6(1);
+            LED_3 = true;
+            LED_6 = true;
             break;
         case 4:
-            ML_LED_4(1);
+            LED_4 = true;
             break;
         case 5:
-            ML_LED_5(1);
+            LED_5 = true;
             break;
         case 6:
-            ML_LED_6(1);
+            LED_6 = true;
             break;
         default:
             break;
     }
+
+#ifdef CAPS_LOCK_STATUS
+    led_t led_state = host_keyboard_led_state();
+    if(led_state.caps_lock) {
+        LED_6 = true;
+    }
+    else {
+        if(layer != 3 && layer != 6) {
+            LED_6 = false;
+        }
+    }
+#endif
+
+    ML_LED_1(LED_1);
+    ML_LED_2(LED_2);
+    ML_LED_3(LED_3);
+    ML_LED_4(LED_4);
+    ML_LED_5(LED_5);
+    ML_LED_6(LED_6);
 
     return state;
 }


### PR DESCRIPTION
When the caps lock LED was first implemented it used layer 1's LED. This is no longer true, so this condition needs to be updated as caps lock is now using an LED for layer 3 and 6. Additionally this PR resolves a race condition happening between the LED layer code, and the caps lock LED code.