### PR TITLE
Added Emacs as a unicode input mode

### DIFF
--- a/quantum/process_keycode/process_unicode_common.c
+++ b/quantum/process_keycode/process_unicode_common.c
@@ -128,6 +128,12 @@ __attribute__((weak)) void unicode_input_finish(void) {
         case UC_WINC:
             tap_code(KC_ENTER);
             break;
+	case UC_EMACS:
+	    // The usual way to type unicode in emacs is C-x-8 <RET> then the unicode number in hex
+	    tap_code16(LCTL(KC_X));
+            tap_code16(KC_8);
+            tap_code16(KC_ENTER);
+            break;
     }
 
     set_mods(unicode_saved_mods);  // Reregister previously set mods
@@ -150,6 +156,9 @@ __attribute__((weak)) void unicode_input_cancel(void) {
         case UC_WIN:
             unregister_code(KC_LALT);
             break;
+	case UC_EMACS:
+	    tap_code16(KC_ENTER);
+	    break;
     }
 
     set_mods(unicode_saved_mods);  // Reregister previously set mods

--- a/quantum/process_keycode/process_unicode_common.h
+++ b/quantum/process_keycode/process_unicode_common.h
@@ -64,6 +64,7 @@ enum unicode_input_modes {
     UC_WIN,    // Windows using EnableHexNumpad
     UC_BSD,    // BSD (not implemented)
     UC_WINC,   // Windows using WinCompose (https://github.com/samhocevar/wincompose)
+    UC_EMACS,  // Emacs is an operating system in search of a good text editor
     UC__COUNT  // Number of available input modes (always leave at the end)
 };
 
@@ -82,7 +83,8 @@ void    set_unicode_input_mode(uint8_t mode);
 void    cycle_unicode_input_mode(int8_t offset);
 void    persist_unicode_input_mode(void);
 
-void unicode_input_start(void);
+void unicode_input_start
+(void);
 void unicode_input_finish(void);
 void unicode_input_cancel(void);
 

--- a/quantum/quantum_keycodes.h
+++ b/quantum/quantum_keycodes.h
@@ -471,6 +471,7 @@ enum quantum_keycodes {
     UNICODE_MODE_WIN,
     UNICODE_MODE_BSD,
     UNICODE_MODE_WINC,
+    UNICODE_MODE_EMACS,
 
     HPT_ON,
     HPT_OFF,
@@ -873,6 +874,7 @@ enum quantum_keycodes {
 #define UC_M_WI UNICODE_MODE_WIN
 #define UC_M_BS UNICODE_MODE_BSD
 #define UC_M_WC UNICODE_MODE_WINC
+#define UC_M_EM UNICODE_MODE_EMACS
 
 #ifdef SWAP_HANDS_ENABLE
 #    define SH_T(kc) (QK_SWAP_HANDS | (kc))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->
I added a new unicode input mode: emacs. (see also: PR in the main qmk branch: https://github.com/qmk/qmk_firmware/pull/16949)

While strictly not an operating system, inserting unicode characters in emacs has its own keybinding. The most usual way is `C-x-8 RET` followed by the unicode in hex. As a person who works across different OSes but with the constant being emacs, this was the most straightforward way forwards. 

Of course, the main credit goes to TrentinQuarantino in this [emacs stack exchange post](https://emacs.stackexchange.com/a/56027).
 
<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

I added a new unicode input mode in `quantum/process_unicode_common.(c|h)`. Then I updated all the programmer friendly numbers of the enums, and added documentation too.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Additional notes

I'm unfamiliar with the testing protocols of this project. If I could get some help that'd be great. I'm reasonably familiar with C. However, what I have done is I have flashed two ergodox-EZs with this and tested it on emacs on both linux and macos. My Windows computer isn't quite available right now, so I'm unable to test on Windows. 