### PR TITLE
Fix firmware version in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ To set up the local build enviroment to create the firmware image manually, head
 And instead of using just `qmk setup`, you will want to run this instead:
 
 ```sh
-qmk setup zsa/qmk_firmware -b firmware20
+qmk setup zsa/qmk_firmware -b firmware21
 ```
 
 ## Maintainers


### PR DESCRIPTION
I tested this by successfully compiling the default Planck EZ layout with the following commands:

```bash
cd qmk_firmware
qmk setup zsa/qmk_firmware -b firmware21
make planck/ez/glow:glow
```
