### PR TITLE
Partial revert of #9941 to fix rolling issues

### DIFF
--- a/quantum/action.c
+++ b/quantum/action.c
@@ -316,6 +316,11 @@ void process_action(keyrecord_t *record, action_t action) {
     uint8_t tap_count = record->tap.count;
 #endif
 
+    if (event.pressed) {
+        // clear the potential weak mods left by previously pressed keys
+        clear_weak_mods();
+    }
+
 #ifndef NO_ACTION_ONESHOT
     bool do_release_oneshot = false;
     // notice we only clear the one shot layer if the pressed key is not a modifier.


### PR DESCRIPTION
qmk#9941 moves the clear weak mods, and causes issues with rolling keystrokes.

A full revert probably isn't best, so this partially reverts it, by calling it at both the old and newer location.   This doesn't appear to have any issues.