### PR TITLE
Fix lag issues when rgblight cannot connect to i2c rgb bridge

### DIFF
--- a/keyboards/ergodox_ez/led_i2c.c
+++ b/keyboards/ergodox_ez/led_i2c.c
@@ -21,35 +21,38 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGBLIGHT_ENABLE
 
 #    include "ergodox_ez.h"
+i2c_status_t i2c_rgblight = 0x20;
+extern bool         i2c_initialized;
 
 void rgblight_call_driver(LED_TYPE *led, uint8_t led_num) {
-    i2c_init();
-    i2c_start(0x84, ERGODOX_EZ_I2C_TIMEOUT);
-    int i = 0;
+    if (i2c_initialized && !mcp23018_status) {
+        if (!i2c_rgblight)  i2c_rgblight = i2c_start(0x84, ERGODOX_EZ_I2C_TIMEOUT);
+
+        uint8_t i = 0;
 #    if defined(ERGODOX_LED_30)
-    // prevent right-half code from trying to bitbang all 30
-    // so with 30 LEDs, we count from 29 to 15 here, and the
-    // other half does 0 to 14.
-    uint8_t half_led_num = RGBLED_NUM / 2;
-    for (i = half_led_num + half_led_num - 1; i >= half_led_num; --i)
+        // prevent right-half code from trying to bitbang all 30
+        // so with 30 LEDs, we count from 29 to 15 here, and the
+        // other half does 0 to 14.
+        uint8_t half_led_num = RGBLED_NUM / 2;
+        for (i = half_led_num + half_led_num - 1; i >= half_led_num; --i)
 #    elif defined(ERGODOX_LED_15_MIRROR)
-    for (i = 0; i < led_num; ++i)
-#    else  // ERGDOX_LED_15 non-mirrored
-    for (i = led_num - 1; i >= 0; --i)
+        for (i = 0; i < led_num; ++i)
+#    else // ERGDOX_LED_15 non-mirrored
+        for (i = led_num - 1; i >= 0; --i)
 #    endif
-    {
-        uint8_t *data = (uint8_t *)(led + i);
-        i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
-        i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
-        i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
-#ifdef RGBW
-        i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
-#endif
+        {
+            uint8_t *data = (uint8_t *)(led + i);
+            if (!i2c_rgblight) i2c_rgblight = i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
+            if (!i2c_rgblight) i2c_rgblight = i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
+            if (!i2c_rgblight) i2c_rgblight = i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
+#    ifdef RGBW
+            if (!i2c_rgblight) i2c_rgblight = i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
+#    endif
+        }
+        i2c_stop();
     }
-    i2c_stop();
 
     ws2812_setleds(led, led_num);
 }
 
-
-#endif  // RGBLIGHT_ENABLE
+#endif // RGBLIGHT_ENABLE

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -63,6 +63,9 @@ static void         unselect_rows(void);
 static void         select_row(uint8_t row);
 
 static uint8_t mcp23018_reset_loop;
+#ifdef RGBLIGHT_ENABLE
+extern i2c_status_t i2c_rgblight;
+#endif
 
 void matrix_init_custom(void) {
     // initialize row and col
@@ -96,6 +99,9 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
                 ergodox_blink_all_leds();
 #ifdef RGB_MATRIX_ENABLE
                 rgb_matrix_init();  // re-init driver on reconnect
+#endif
+#ifdef RGBLIGHT_ENABLE
+                i2c_rgblight = 0x20; // re-enable rgb light
 #endif
             }
         }


### PR DESCRIPTION
if the i2c bridge for the rgb leds can't be found, it waits an excessive amount of time. This causes noticeable lag. 

This fixes it that, by not calling the commands if there has been an error communicating with the i2c bridge.