### PR TITLE
More aggressively send shift mod for autoshift and caps word

### DIFF
--- a/quantum/process_keycode/process_auto_shift.c
+++ b/quantum/process_keycode/process_auto_shift.c
@@ -95,6 +95,7 @@ __attribute__((weak)) bool get_auto_shift_no_auto_repeat(uint16_t keycode, keyre
 __attribute__((weak)) void autoshift_press_user(uint16_t keycode, bool shifted, keyrecord_t *record) {
     if (shifted) {
         add_weak_mods(MOD_BIT(KC_LSFT));
+        send_keyboard_report();
     }
     register_code16((IS_RETRO(keycode)) ? keycode & 0xFF : keycode);
 }

--- a/quantum/process_keycode/process_caps_word.c
+++ b/quantum/process_keycode/process_caps_word.c
@@ -152,6 +152,7 @@ __attribute__((weak)) bool caps_word_press_user(uint16_t keycode) {
         case KC_A ... KC_Z:
         case KC_MINS:
             add_weak_mods(MOD_BIT(KC_LSFT)); // Apply shift to next key.
+            send_keyboard_report();
             return true;
 
         // Keycodes that continue Caps Word, without shifting.


### PR DESCRIPTION
Fixes some issues with Auto Shift and Caps Words (both when used separately or together. 



