### PR TITLE
Reduce i2c timeouts for rgb led supported hardware

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.h
+++ b/keyboards/ergodox_ez/ergodox_ez.h
@@ -45,7 +45,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define OLATB           0x15
 
 extern i2c_status_t mcp23018_status;
-#define ERGODOX_EZ_I2C_TIMEOUT 100
+#ifndef ERGODOX_EZ_I2C_TIMEOUT
+#    define ERGODOX_EZ_I2C_TIMEOUT 80
+#endif
 
 void init_ergodox(void);
 void ergodox_blink_all_leds(void);

--- a/keyboards/ergodox_ez/led_i2c.c
+++ b/keyboards/ergodox_ez/led_i2c.c
@@ -21,12 +21,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef RGBLIGHT_ENABLE
 
 #    include "ergodox_ez.h"
-bool  i2c_rgblight = true;
-extern bool         i2c_initialized;
+bool        i2c_rgblight = true;
+extern bool i2c_initialized;
+#    ifndef ERGODOX_RGBLIGHT_TIMEOUT
+#        define ERGODOX_RGBLIGHT_TIMEOUT 5
+#    endif
 
 void rgblight_call_driver(LED_TYPE *led, uint8_t led_num) {
     if (i2c_initialized && !mcp23018_status && i2c_rgblight) {
-        if (i2c_start(0x84, ERGODOX_EZ_I2C_TIMEOUT)) {
+        if (i2c_start(0x84, ERGODOX_RGBLIGHT_TIMEOUT)) {
             i2c_rgblight = false;
             i2c_stop();
         } else {
@@ -44,11 +47,11 @@ void rgblight_call_driver(LED_TYPE *led, uint8_t led_num) {
 #    endif
             {
                 uint8_t *data = (uint8_t *)(led + i);
-                i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
-                i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
-                i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
+                i2c_write(*data++, ERGODOX_RGBLIGHT_TIMEOUT);
+                i2c_write(*data++, ERGODOX_RGBLIGHT_TIMEOUT);
+                i2c_write(*data++, ERGODOX_RGBLIGHT_TIMEOUT);
 #    ifdef RGBW
-                i2c_write(*data++, ERGODOX_EZ_I2C_TIMEOUT);
+                i2c_write(*data++, ERGODOX_RGBLIGHT_TIMEOUT);
 #    endif
             }
             i2c_stop();

--- a/keyboards/ergodox_ez/matrix.c
+++ b/keyboards/ergodox_ez/matrix.c
@@ -102,7 +102,7 @@ bool matrix_scan_custom(matrix_row_t current_matrix[]) {
 #endif
 #ifdef RGBLIGHT_ENABLE
                 i2c_rgblight = true; // re-enable rgb light
-                rgblight_init();
+                rgblight_set();
 #endif
             }
         }

--- a/keyboards/ergodox_ez/post_config.h
+++ b/keyboards/ergodox_ez/post_config.h
@@ -33,8 +33,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef ERGODOX_LED_30
 // If using 30 LEDs, then define that many
-#    define RGBLED_NUM 30  // Number of LEDs
+#    define RGBLED_NUM 30 // Number of LEDs
 #else
 // If not, then only define 15
-#    define RGBLED_NUM 15  // Number of LEDs
+#    define RGBLED_NUM 15 // Number of LEDs
+#endif
+
+#ifndef ISSI_TIMEOUT
+#    define ISSI_TIMEOUT 3
 #endif

--- a/keyboards/moonlander/post_config.h
+++ b/keyboards/moonlander/post_config.h
@@ -14,7 +14,4 @@
 #    ifndef ISSI_TIMEOUT
 #        define ISSI_TIMEOUT 5
 #    endif
-#    if !defined(MOONLANDER_I2C_TIMEOUT) && ISSI_TIMEOUT < 10
-#        define MOONLANDER_I2C_TIMEOUT (10 - ISSI_TIMEOUT)
-#    endif
 #endif

--- a/keyboards/moonlander/post_config.h
+++ b/keyboards/moonlander/post_config.h
@@ -1,9 +1,20 @@
+#pragma once
+
 #ifdef AUDIO_ENABLE
-#ifndef STARTUP_SONG
-#    define STARTUP_SONG SONG(E__NOTE(_DS5), E__NOTE(_D5), E__NOTE(_AS4), Q__NOTE(_F5))
+#    ifndef STARTUP_SONG
+#        define STARTUP_SONG SONG(E__NOTE(_DS5), E__NOTE(_D5), E__NOTE(_AS4), Q__NOTE(_F5))
+#    endif
+
+#    ifndef GOODBYE_SONG
+#        define GOODBYE_SONG SONG(E__NOTE(_D5), E__NOTE(_F5), E__NOTE(_C5), Q__NOTE(_AS4))
+#    endif
 #endif
 
-#ifndef GOODBYE_SONG
-#    define GOODBYE_SONG SONG(E__NOTE(_D5), E__NOTE(_F5), E__NOTE(_C5), Q__NOTE(_AS4))
-#endif
+#ifdef RGB_MATIRX_ENABLE
+#    ifndef ISSI_TIMEOUT
+#        define ISSI_TIMEOUT 5
+#    endif
+#    if !defined(MOONLANDER_I2C_TIMEOUT) && ISSI_TIMEOUT < 10
+#        define MOONLANDER_I2C_TIMEOUT (10 - ISSI_TIMEOUT)
+#    endif
 #endif

--- a/keyboards/moonlander/post_config.h
+++ b/keyboards/moonlander/post_config.h
@@ -10,8 +10,6 @@
 #    endif
 #endif
 
-#ifdef RGB_MATIRX_ENABLE
-#    ifndef ISSI_TIMEOUT
-#        define ISSI_TIMEOUT 5
-#    endif
+#ifndef ISSI_TIMEOUT
+#    define ISSI_TIMEOUT 5
 #endif


### PR DESCRIPTION
Reduces the wait time for when i2c devices are not responding (eg, second half disconnected). This should improve performance and usability when only one half is connected. 