### PR TITLE
Check Podman before Docker;

### DIFF
--- a/util/docker_build.sh
+++ b/util/docker_build.sh
@@ -20,13 +20,13 @@ if [ $# -gt 1 ]; then
 fi
 
 # Allow $RUNTIME to be overriden by the user as an environment variable
-# Else check if either docker or podman exit and set them as runtime
+# Else check if either podman or docker exit and set them as runtime
 # if none are found error out
 if [ -z "$RUNTIME" ]; then
-	if command -v docker >/dev/null 2>&1; then
-		RUNTIME="docker"
-	elif command -v podman >/dev/null 2>&1; then
+	if command -v podman >/dev/null 2>&1; then
 		RUNTIME="podman"
+	elif command -v docker >/dev/null 2>&1; then
+		RUNTIME="docker"
 	else
 		errcho "Error: no compatible container runtime found."
 		errcho "Either podman or docker are required."


### PR DESCRIPTION
- util/docker_build.sh
  - Reordered the check to determine whether Docker or Podman is installed.
  - Checking Podman first ensures that it will detect the correct runtime if the user happens to have aliased docker to podman.