### PR TITLE
fix: explicitely import string.h in the oryx protocol files

### DIFF
--- a/quantum/oryx.c
+++ b/quantum/oryx.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "oryx.h"
 #include "eeprom.h"
 


### PR DESCRIPTION
Funny enough, the string.h file was never included on Lufa if NKRO was disabled.
As a result the Oryx protocol code making use of the memcpy function wasn't compiling, the fix is to simply include the header file in the oryx protocol files.