### PR TITLE
Fix for Caps Lock indicator turning off 3rd LED in layers !=3

### DIFF
--- a/keyboards/ergodox_ez/ergodox_ez.c
+++ b/keyboards/ergodox_ez/ergodox_ez.c
@@ -458,7 +458,7 @@ void matrix_scan_kb(void) {
     }
     else {
         uint8_t layer = get_highest_layer(layer_state);
-        if(layer != 3) {
+        if(layer < 3) {
             ergodox_right_led_3_off();
         }
     }


### PR DESCRIPTION
With the current caps lock function, any layer != 3 that uses the Blue RGB layer indicator gets switched off regardless of whether caps lock is on. If for example one wanted to use layer 5 which uses `ergodox_right_led_1` and `ergodox_right_led_3`, the 3rd LED would turn off.

The fix is pretty simple, to check to see if `layer < 3`. The downside of this solution is that if the user is on a layer that utilizes the 3rd LED, there really isn't any kind of feedback to indicate that the caps lock is on. Unfortunately, I'm not familiar enough with the firmware or the hardware to throw something together.
 