### PR TITLE
feat: adds halfmoon

### DIFF
--- a/keyboards/moonlander/matrix.c
+++ b/keyboards/moonlander/matrix.c
@@ -87,9 +87,8 @@ void matrix_init_custom(void) {
     setPinInputLow(A7);
     setPinInputLow(B0);
 
-    #ifdef HALFMOON
     is_launching = true;
-    #else
+    #ifndef HALFMOON
     mcp23018_init();
     #endif
 }
@@ -221,11 +220,9 @@ void matrix_power_up(void) {
         ML_LED_2(false);
         ML_LED_3(false);
 
-        #ifndef HALFMOON
         ML_LED_4(false);
         ML_LED_5(false);
         ML_LED_6(false);
-        #endif
     }
 
     // initialize matrix state: all keys off

--- a/keyboards/moonlander/matrix.c
+++ b/keyboards/moonlander/matrix.c
@@ -87,7 +87,11 @@ void matrix_init_custom(void) {
     setPinInputLow(A7);
     setPinInputLow(B0);
 
+    #ifdef HALFMOON
+    is_launching = true;
+    #else
     mcp23018_init();
+    #endif
 }
 
 bool matrix_scan_custom(matrix_row_t current_matrix[]) {
@@ -216,9 +220,12 @@ void matrix_power_up(void) {
         ML_LED_1(false);
         ML_LED_2(false);
         ML_LED_3(false);
+
+        #ifndef HALFMOON
         ML_LED_4(false);
         ML_LED_5(false);
         ML_LED_6(false);
+        #endif
     }
 
     // initialize matrix state: all keys off

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -42,11 +42,9 @@ void moonlander_led_task(void) {
         ML_LED_1(false);
         ML_LED_2(false);
         ML_LED_3(false);
-        #ifndef HALFMOON
         ML_LED_4(false);
         ML_LED_5(false);
         ML_LED_6(false);
-        #endif
 
         ML_LED_1(true);
         wait_ms(250);
@@ -54,28 +52,32 @@ void moonlander_led_task(void) {
         wait_ms(250);
         ML_LED_3(true);
         wait_ms(250);
-        #ifndef HALFMOON
-        ML_LED_4(true);
-        wait_ms(250);
-        ML_LED_5(true);
-        wait_ms(250);
-        ML_LED_6(true);
-        wait_ms(250);
-        #endif
+    
+        if (is_transport_connected()) {
+            ML_LED_4(true);
+            wait_ms(250);
+            ML_LED_5(true);
+            wait_ms(250);
+            ML_LED_6(true);
+            wait_ms(250);
+        }
+
         ML_LED_1(false);
         wait_ms(250);
         ML_LED_2(false);
         wait_ms(250);
         ML_LED_3(false);
         wait_ms(250);
-        #ifndef HALFMOON
-        ML_LED_4(false);
-        wait_ms(250);
-        ML_LED_5(false);
-        wait_ms(250);
-        ML_LED_6(false);
-        wait_ms(250);
-        #endif
+
+        if (is_transport_connected()) {
+            ML_LED_4(false);
+            wait_ms(250);
+            ML_LED_5(false);
+            wait_ms(250);
+            ML_LED_6(false);
+            wait_ms(250);
+        }
+
         is_launching = false;
         layer_state_set_kb(layer_state);
     }

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -42,9 +42,11 @@ void moonlander_led_task(void) {
         ML_LED_1(false);
         ML_LED_2(false);
         ML_LED_3(false);
+        #ifndef HALFMOON
         ML_LED_4(false);
         ML_LED_5(false);
         ML_LED_6(false);
+        #endif
 
         ML_LED_1(true);
         wait_ms(250);
@@ -52,24 +54,28 @@ void moonlander_led_task(void) {
         wait_ms(250);
         ML_LED_3(true);
         wait_ms(250);
+        #ifndef HALFMOON
         ML_LED_4(true);
         wait_ms(250);
         ML_LED_5(true);
         wait_ms(250);
         ML_LED_6(true);
         wait_ms(250);
+        #endif
         ML_LED_1(false);
         wait_ms(250);
         ML_LED_2(false);
         wait_ms(250);
         ML_LED_3(false);
         wait_ms(250);
+        #ifndef HALFMOON
         ML_LED_4(false);
         wait_ms(250);
         ML_LED_5(false);
         wait_ms(250);
         ML_LED_6(false);
         wait_ms(250);
+        #endif
         is_launching = false;
         layer_state_set_kb(layer_state);
     }
@@ -358,6 +364,16 @@ void keyboard_post_init_kb(void) {
 
 #if defined(AUDIO_ENABLE) && defined(MUSIC_MAP)
 // clang-format off
+#ifdef HALFMOON
+const uint8_t music_map[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_halfmoon(
+    58, 59, 60, 61, 62, 63, 64,
+    44, 45, 46, 47, 48, 49, 50,
+    30, 31, 32, 33, 34, 35, 36,
+    18, 19, 20, 21, 22, 23,
+     8,  9, 10, 11, 12,      3,
+                     0,  1,  2
+);
+#else
 const uint8_t music_map[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_moonlander(
     58, 59, 60, 61, 62, 63, 64,    65, 66, 67, 68, 69, 70, 71,
     44, 45, 46, 47, 48, 49, 50,    51, 52, 53, 54, 55, 56, 57,
@@ -366,6 +382,7 @@ const uint8_t music_map[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_moonlander(
      8,  9, 10, 11, 12,      3,     4,     13, 14, 15, 16, 17,
                      0,  1,  2,     5,  6,  7
 );
+#endif
 // clang-format on
 #endif
 
@@ -395,9 +412,11 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                     ML_LED_1(false);
                     ML_LED_2(false);
                     ML_LED_3(false);
+                    #ifndef HALFMOON
                     ML_LED_4(false);
                     ML_LED_5(false);
                     ML_LED_6(false);
+                    #endif
                 }
             }
             break;

--- a/keyboards/moonlander/moonlander.c
+++ b/keyboards/moonlander/moonlander.c
@@ -368,11 +368,11 @@ void keyboard_post_init_kb(void) {
 // clang-format off
 #ifdef HALFMOON
 const uint8_t music_map[MATRIX_ROWS][MATRIX_COLS] = LAYOUT_halfmoon(
-    58, 59, 60, 61, 62, 63, 64,
-    44, 45, 46, 47, 48, 49, 50,
-    30, 31, 32, 33, 34, 35, 36,
-    18, 19, 20, 21, 22, 23,
-     8,  9, 10, 11, 12,      3,
+    29, 30, 31, 32, 33, 34, 35,
+    22, 23, 24, 25, 26, 27, 28,
+    15, 16, 17, 18, 19, 20, 21,
+     9, 10, 11, 12, 13, 14,
+     4,  5,  6,  7,  8,      3,
                      0,  1,  2
 );
 #else

--- a/keyboards/moonlander/moonlander.h
+++ b/keyboards/moonlander/moonlander.h
@@ -35,6 +35,32 @@ extern bool mcp23018_leds[];
 #define ML_LED_6(status) mcp23018_leds[2] = (bool)status
 
 // clang-format off
+#ifdef HALFMOON
+#define LAYOUT_halfmoon( \
+    k00, k01, k02, k03, k04, k05, k06, \
+    k07, k08, k09, k10, k11, k12, k13, \
+    k14, k15, k16, k17, k18, k19, k20, \
+    k21, k22, k23, k24, k25, k26,      \
+    k27, k28, k29, k30, k31,      k32, \
+                        k33, k34, k35  \
+) \
+{ \
+    { k00, k01, k02, k03, k04, k05, k06 }, \
+    { k07, k08, k09, k10, k11, k12, k13 }, \
+    { k14, k15, k16, k17, k18, k19, k20 }, \
+    { k21, k22, k23, k24, k25, k26, KC_NO }, \
+    { k27, k28, k29, k30, k31, KC_NO, KC_NO }, \
+    { k33, k34, k35, k32, KC_NO, KC_NO, KC_NO }, \
+\
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO }, \
+    { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO  } \
+}
+// clang-format on
+#else
 #define LAYOUT_moonlander( \
     k00, k01, k02, k03, k04, k05, k06,   k60, k61, k62, k63, k64, k65, k66, \
     k10, k11, k12, k13, k14, k15, k16,   k70, k71, k72, k73, k74, k75, k76, \
@@ -59,6 +85,7 @@ extern bool mcp23018_leds[];
     { KC_NO, KC_NO, KC_NO, kb3, kb4, kb5, kb6  } \
 }
 // clang-format on
+#endif
 
 enum planck_ez_keycodes {
     TOGGLE_LAYER_COLOR = SAFE_RANGE,

--- a/keyboards/moonlander/moonlander.h
+++ b/keyboards/moonlander/moonlander.h
@@ -35,7 +35,6 @@ extern bool mcp23018_leds[];
 #define ML_LED_6(status) mcp23018_leds[2] = (bool)status
 
 // clang-format off
-#ifdef HALFMOON
 #define LAYOUT_halfmoon( \
     k00, k01, k02, k03, k04, k05, k06, \
     k07, k08, k09, k10, k11, k12, k13, \
@@ -60,7 +59,6 @@ extern bool mcp23018_leds[];
     { KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO, KC_NO  } \
 }
 // clang-format on
-#else
 #define LAYOUT_moonlander( \
     k00, k01, k02, k03, k04, k05, k06,   k60, k61, k62, k63, k64, k65, k66, \
     k10, k11, k12, k13, k14, k15, k16,   k70, k71, k72, k73, k74, k75, k76, \
@@ -85,7 +83,6 @@ extern bool mcp23018_leds[];
     { KC_NO, KC_NO, KC_NO, kb3, kb4, kb5, kb6  } \
 }
 // clang-format on
-#endif
 
 enum planck_ez_keycodes {
     TOGGLE_LAYER_COLOR = SAFE_RANGE,


### PR DESCRIPTION
This adds the Halfmoon variant to the Moonlander firmwares. Since the Halfmoon is one left half only, this PR disables all coms to the mcp23018 behind a `HALFMOON` define.