### PR TITLE
fix: always call layer_state_set_user

### DIFF
--- a/keyboards/zsa/moonlander/moonlander.c
+++ b/keyboards/zsa/moonlander/moonlander.c
@@ -118,8 +118,8 @@ void keyboard_pre_init_kb(void) {
 }
 
 layer_state_t layer_state_set_kb(layer_state_t state) {
-#if !defined(MOONLANDER_USER_LEDS)
     state = layer_state_set_user(state);
+#if !defined(MOONLANDER_USER_LEDS)
 #    ifdef ORYX_ENABLE
     layer_state_set_oryx(state);
     if (rawhid_state.status_led_control) return state;


### PR DESCRIPTION
## Description

Before commit b46f5e2e46eb51b92bc17f238fb8d65e95c3224b, layer_state_set_kb was only defined if MOONLANDER_USER_LEDS was not set. With MOONLANDER_USER_LEDS set, the default layer_state_set_kb provided by QMK takes care of calling layer_state_set_user.

After that commit, layer_state_set_kb is defined unconditionally, but most of its body is still ifdef'd out if MOONLANDER_USER_LEDS is set. That includes layer_state_set_user, which looks like an oversight.

Run layer_state_set_user unconditionally.

This is the same fix as #396 for voyager. It looks like the other ZSA keyboards do not have the same problem.

Alternatively, we could go back to the old approach of defining the function conditionally, but this makes it a little harder to reintroduce the same problem.

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
