### PR TITLE
fix: Oryx layer update does no t work if VOYAGER_USER_LEDS defined

### DIFF
--- a/keyboards/zsa/voyager/voyager.c
+++ b/keyboards/zsa/voyager/voyager.c
@@ -95,9 +95,12 @@ void keyboard_pre_init_kb(void) {
 
 layer_state_t layer_state_set_kb(layer_state_t state) {
     state = layer_state_set_user(state);
+#ifdef ORYX_ENABLE
+    layer_state_set_oryx(state);
+#endif
+
 #if !defined(VOYAGER_USER_LEDS)
 #    ifdef ORYX_ENABLE
-    layer_state_set_oryx(state);
     if (rawhid_state.status_led_control) return state;
 #    endif
     if (is_launching || !keyboard_config.led_level) return state;


### PR DESCRIPTION
## Description
In case when `ORYX_ENABLE` and `VOYAGER_USER_LEDS` are both defined, `layer_state_set_oryx` is not called and there're no layer updates to Oryx/Keymapp.

Moved the call outside of `#if !defined(VOYAGER_USER_LEDS)` block.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
