### PR TITLE
fix: (Moonlander) User code not called and Oryx status not updated on layer switch with MOONLANDER_USER_LEDS defined

### DIFF
--- a/keyboards/zsa/moonlander/moonlander.c
+++ b/keyboards/zsa/moonlander/moonlander.c
@@ -138,10 +138,13 @@ void keyboard_pre_init_kb(void) {
 }
 
 layer_state_t layer_state_set_kb(layer_state_t state) {
-#if !defined(MOONLANDER_USER_LEDS)
     state = layer_state_set_user(state);
-#    ifdef ORYX_ENABLE
+#ifdef ORYX_ENABLE
     layer_state_set_oryx(state);
+#endif
+
+#if !defined(MOONLANDER_USER_LEDS)
+#    ifdef ORYX_ENABLE
     if (rawhid_state.status_led_control) return state;
 #    endif
     if (is_launching || !keyboard_config.led_level) return state;


### PR DESCRIPTION
If  `MOONLANDER_USER_LEDS` symbol is defined, `layer_state_set_user` and `layer_state_set_oryx` are not called, hence:
* user code layer updates are not applied,
* layer status in Oryx and Keymapp is not updated.

## Description
Moved calls outside of `#if !defined(MOONLANDER_USER_LEDS)` block, keeping `layer_state_set_oryx` dependent on `ORYX_ENABLED` definition.

## Types of Changes
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation