### PR TITLE
bug: fix auto mouse layer getting stuck with TO keycodes

### DIFF
--- a/quantum/pointing_device/pointing_device_auto_mouse.c
+++ b/quantum/pointing_device/pointing_device_auto_mouse.c
@@ -352,6 +352,8 @@ bool process_auto_mouse(uint16_t keycode, keyrecord_t* record) {
         case QK_TO ... QK_TO_MAX:
             if (QK_TO_GET_LAYER(keycode) == (AUTO_MOUSE_TARGET_LAYER)) {
                 if (!(record->event.pressed)) auto_mouse_toggle();
+            } else {
+                auto_mouse_context.status.is_toggled = false;
             }
             break;
         // TG((AUTO_MOUSE_TARGET_LAYER))-------------------------------------------------------------------------------


### PR DESCRIPTION
Brute force fix.  Since the layer shouldn't be on when calling TO (since that clears the whole stack and sets the one layer), this should be safe.  And can confirm it fixes the getting stuck. 