### PR TITLE
Use zsa/defaults module in Moonlander keymaps

### DIFF
--- a/keyboards/zsa/moonlander/keymaps/default/keymap.json
+++ b/keyboards/zsa/moonlander/keymaps/default/keymap.json
@@ -1,0 +1,5 @@
+{
+    "modules": [
+        "zsa/defaults"
+    ]
+}

--- a/keyboards/zsa/moonlander/keymaps/oryx/keymap.json
+++ b/keyboards/zsa/moonlander/keymaps/oryx/keymap.json
@@ -1,5 +1,6 @@
 {
     "modules": [
+        "zsa/defaults",
         "zsa/oryx"
     ]
 }


### PR DESCRIPTION
## Description

I was unable to compile the Moonlander layouts until I added the `zsa/defaults` module to each keymap.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/A

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
