### PR TITLE
Fix touchpad descriptor nesting inside SharedReport

### DIFF
--- a/tmk_core/protocol/usb_descriptor.c
+++ b/tmk_core/protocol/usb_descriptor.c
@@ -311,7 +311,7 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
 #    endif
 #endif
 
-#ifdef DIGITIZER_ENABLE
+#if defined(DIGITIZER_ENABLE) && !defined(DIGITIZER_MODE_TOUCHPAD)
 #    ifndef DIGITIZER_SHARED_EP
 const USB_Descriptor_HIDReport_Datatype_t PROGMEM DigitizerReport[] = {
 #    elif !defined(SHARED_REPORT_STARTED)
@@ -405,8 +405,103 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
         HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),               \
         HID_RI_POP(0),                                                                     \
     HID_RI_END_COLLECTION(0)
+#endif // DIGITIZER_MODE_TOUCHPAD (macros only - report decl relocated below after SharedReport closes)
 
-// Digitizer/Touchpad HID Descriptor
+#if defined(SHARED_EP_ENABLE) && !defined(SHARED_REPORT_STARTED)
+const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
+#endif
+
+#ifdef EXTRAKEY_ENABLE
+    HID_RI_USAGE_PAGE(8, 0x01),           // Generic Desktop
+    HID_RI_USAGE(8, 0x80),                // System Control
+    HID_RI_COLLECTION(8, 0x01),           // Application
+        HID_RI_REPORT_ID(8, REPORT_ID_SYSTEM),
+        HID_RI_USAGE_MINIMUM(8, 0x01),    // Pointer
+        HID_RI_USAGE_MAXIMUM(16, 0x00B7), // System Display LCD Autoscale
+        HID_RI_LOGICAL_MINIMUM(8, 0x01),
+        HID_RI_LOGICAL_MAXIMUM(16, 0x00B7),
+        HID_RI_REPORT_COUNT(8, 1),
+        HID_RI_REPORT_SIZE(8, 16),
+        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_ARRAY | HID_IOF_ABSOLUTE),
+    HID_RI_END_COLLECTION(0),
+
+    HID_RI_USAGE_PAGE(8, 0x0C),           // Consumer
+    HID_RI_USAGE(8, 0x01),                // Consumer Control
+    HID_RI_COLLECTION(8, 0x01),           // Application
+        HID_RI_REPORT_ID(8, REPORT_ID_CONSUMER),
+        HID_RI_USAGE_MINIMUM(8, 0x01),    // Consumer Control
+        HID_RI_USAGE_MAXIMUM(16, 0x02A0), // AC Desktop Show All Applications
+        HID_RI_LOGICAL_MINIMUM(8, 0x01),
+        HID_RI_LOGICAL_MAXIMUM(16, 0x02A0),
+        HID_RI_REPORT_COUNT(8, 1),
+        HID_RI_REPORT_SIZE(8, 16),
+        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_ARRAY | HID_IOF_ABSOLUTE),
+    HID_RI_END_COLLECTION(0),
+#endif
+
+#ifdef PROGRAMMABLE_BUTTON_ENABLE
+    HID_RI_USAGE_PAGE(8, 0x0C),            // Consumer
+    HID_RI_USAGE(8, 0x01),                 // Consumer Control
+    HID_RI_COLLECTION(8, 0x01),            // Application
+        HID_RI_REPORT_ID(8, REPORT_ID_PROGRAMMABLE_BUTTON),
+        HID_RI_USAGE(8, 0x03),             // Programmable Buttons
+        HID_RI_COLLECTION(8, 0x04),        // Named Array
+            HID_RI_USAGE_PAGE(8, 0x09),    // Button
+            HID_RI_USAGE_MINIMUM(8, 0x01), // Button 1
+            HID_RI_USAGE_MAXIMUM(8, 0x20), // Button 32
+            HID_RI_LOGICAL_MINIMUM(8, 0x00),
+            HID_RI_LOGICAL_MAXIMUM(8, 0x01),
+            HID_RI_REPORT_COUNT(8, 32),
+            HID_RI_REPORT_SIZE(8, 1),
+            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+        HID_RI_END_COLLECTION(0),
+    HID_RI_END_COLLECTION(0),
+#endif
+
+#ifdef NKRO_ENABLE
+    HID_RI_USAGE_PAGE(8, 0x01),        // Generic Desktop
+    HID_RI_USAGE(8, 0x06),             // Keyboard
+    HID_RI_COLLECTION(8, 0x01),        // Application
+        HID_RI_REPORT_ID(8, REPORT_ID_NKRO),
+        // Modifiers (8 bits)
+        HID_RI_USAGE_PAGE(8, 0x07),    // Keyboard/Keypad
+        HID_RI_USAGE_MINIMUM(8, 0xE0), // Keyboard Left Control
+        HID_RI_USAGE_MAXIMUM(8, 0xE7), // Keyboard Right GUI
+        HID_RI_LOGICAL_MINIMUM(8, 0x00),
+        HID_RI_LOGICAL_MAXIMUM(8, 0x01),
+        HID_RI_REPORT_COUNT(8, 0x08),
+        HID_RI_REPORT_SIZE(8, 0x01),
+        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+        // Keycodes
+        HID_RI_USAGE_PAGE(8, 0x07),    // Keyboard/Keypad
+        HID_RI_USAGE_MINIMUM(8, 0x00),
+        HID_RI_USAGE_MAXIMUM(8, NKRO_REPORT_BITS * 8 - 1),
+        HID_RI_LOGICAL_MINIMUM(8, 0x00),
+        HID_RI_LOGICAL_MAXIMUM(8, 0x01),
+        HID_RI_REPORT_COUNT(8, NKRO_REPORT_BITS * 8),
+        HID_RI_REPORT_SIZE(8, 0x01),
+        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
+
+        // Status LEDs (5 bits)
+        HID_RI_USAGE_PAGE(8, 0x08),    // LED
+        HID_RI_USAGE_MINIMUM(8, 0x01), // Num Lock
+        HID_RI_USAGE_MAXIMUM(8, 0x05), // Kana
+        HID_RI_REPORT_COUNT(8, 0x05),
+        HID_RI_REPORT_SIZE(8, 0x01),
+        HID_RI_OUTPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE | HID_IOF_NON_VOLATILE),
+        // LED padding (3 bits)
+        HID_RI_REPORT_COUNT(8, 0x01),
+        HID_RI_REPORT_SIZE(8, 0x03),
+        HID_RI_OUTPUT(8, HID_IOF_CONSTANT),
+    HID_RI_END_COLLECTION(0),
+#endif
+
+#ifdef SHARED_EP_ENABLE
+};
+#endif
+
+#ifdef DIGITIZER_MODE_TOUCHPAD
+// Digitizer/Touchpad HID Descriptor (relocated to avoid nesting inside SharedReport)
 const USB_Descriptor_HIDReport_Datatype_t PROGMEM DigitizerTouchpadReport[] = {
     HID_RI_USAGE_PAGE(8, 0x0D),            // Digitizers
     HID_RI_USAGE(8, 0x05),                 // Touchpad
@@ -550,100 +645,7 @@ const USB_Descriptor_HIDReport_Datatype_t PROGMEM DigitizerTouchpadReport[] = {
         HID_RI_END_COLLECTION(0),
     HID_RI_END_COLLECTION(0),
 };
-#endif
-
-#if defined(SHARED_EP_ENABLE) && !defined(SHARED_REPORT_STARTED)
-const USB_Descriptor_HIDReport_Datatype_t PROGMEM SharedReport[] = {
-#endif
-
-#ifdef EXTRAKEY_ENABLE
-    HID_RI_USAGE_PAGE(8, 0x01),           // Generic Desktop
-    HID_RI_USAGE(8, 0x80),                // System Control
-    HID_RI_COLLECTION(8, 0x01),           // Application
-        HID_RI_REPORT_ID(8, REPORT_ID_SYSTEM),
-        HID_RI_USAGE_MINIMUM(8, 0x01),    // Pointer
-        HID_RI_USAGE_MAXIMUM(16, 0x00B7), // System Display LCD Autoscale
-        HID_RI_LOGICAL_MINIMUM(8, 0x01),
-        HID_RI_LOGICAL_MAXIMUM(16, 0x00B7),
-        HID_RI_REPORT_COUNT(8, 1),
-        HID_RI_REPORT_SIZE(8, 16),
-        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_ARRAY | HID_IOF_ABSOLUTE),
-    HID_RI_END_COLLECTION(0),
-
-    HID_RI_USAGE_PAGE(8, 0x0C),           // Consumer
-    HID_RI_USAGE(8, 0x01),                // Consumer Control
-    HID_RI_COLLECTION(8, 0x01),           // Application
-        HID_RI_REPORT_ID(8, REPORT_ID_CONSUMER),
-        HID_RI_USAGE_MINIMUM(8, 0x01),    // Consumer Control
-        HID_RI_USAGE_MAXIMUM(16, 0x02A0), // AC Desktop Show All Applications
-        HID_RI_LOGICAL_MINIMUM(8, 0x01),
-        HID_RI_LOGICAL_MAXIMUM(16, 0x02A0),
-        HID_RI_REPORT_COUNT(8, 1),
-        HID_RI_REPORT_SIZE(8, 16),
-        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_ARRAY | HID_IOF_ABSOLUTE),
-    HID_RI_END_COLLECTION(0),
-#endif
-
-#ifdef PROGRAMMABLE_BUTTON_ENABLE
-    HID_RI_USAGE_PAGE(8, 0x0C),            // Consumer
-    HID_RI_USAGE(8, 0x01),                 // Consumer Control
-    HID_RI_COLLECTION(8, 0x01),            // Application
-        HID_RI_REPORT_ID(8, REPORT_ID_PROGRAMMABLE_BUTTON),
-        HID_RI_USAGE(8, 0x03),             // Programmable Buttons
-        HID_RI_COLLECTION(8, 0x04),        // Named Array
-            HID_RI_USAGE_PAGE(8, 0x09),    // Button
-            HID_RI_USAGE_MINIMUM(8, 0x01), // Button 1
-            HID_RI_USAGE_MAXIMUM(8, 0x20), // Button 32
-            HID_RI_LOGICAL_MINIMUM(8, 0x00),
-            HID_RI_LOGICAL_MAXIMUM(8, 0x01),
-            HID_RI_REPORT_COUNT(8, 32),
-            HID_RI_REPORT_SIZE(8, 1),
-            HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
-        HID_RI_END_COLLECTION(0),
-    HID_RI_END_COLLECTION(0),
-#endif
-
-#ifdef NKRO_ENABLE
-    HID_RI_USAGE_PAGE(8, 0x01),        // Generic Desktop
-    HID_RI_USAGE(8, 0x06),             // Keyboard
-    HID_RI_COLLECTION(8, 0x01),        // Application
-        HID_RI_REPORT_ID(8, REPORT_ID_NKRO),
-        // Modifiers (8 bits)
-        HID_RI_USAGE_PAGE(8, 0x07),    // Keyboard/Keypad
-        HID_RI_USAGE_MINIMUM(8, 0xE0), // Keyboard Left Control
-        HID_RI_USAGE_MAXIMUM(8, 0xE7), // Keyboard Right GUI
-        HID_RI_LOGICAL_MINIMUM(8, 0x00),
-        HID_RI_LOGICAL_MAXIMUM(8, 0x01),
-        HID_RI_REPORT_COUNT(8, 0x08),
-        HID_RI_REPORT_SIZE(8, 0x01),
-        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
-        // Keycodes
-        HID_RI_USAGE_PAGE(8, 0x07),    // Keyboard/Keypad
-        HID_RI_USAGE_MINIMUM(8, 0x00),
-        HID_RI_USAGE_MAXIMUM(8, NKRO_REPORT_BITS * 8 - 1),
-        HID_RI_LOGICAL_MINIMUM(8, 0x00),
-        HID_RI_LOGICAL_MAXIMUM(8, 0x01),
-        HID_RI_REPORT_COUNT(8, NKRO_REPORT_BITS * 8),
-        HID_RI_REPORT_SIZE(8, 0x01),
-        HID_RI_INPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE),
-
-        // Status LEDs (5 bits)
-        HID_RI_USAGE_PAGE(8, 0x08),    // LED
-        HID_RI_USAGE_MINIMUM(8, 0x01), // Num Lock
-        HID_RI_USAGE_MAXIMUM(8, 0x05), // Kana
-        HID_RI_REPORT_COUNT(8, 0x05),
-        HID_RI_REPORT_SIZE(8, 0x01),
-        HID_RI_OUTPUT(8, HID_IOF_DATA | HID_IOF_VARIABLE | HID_IOF_ABSOLUTE | HID_IOF_NON_VOLATILE),
-        // LED padding (3 bits)
-        HID_RI_REPORT_COUNT(8, 0x01),
-        HID_RI_REPORT_SIZE(8, 0x03),
-        HID_RI_OUTPUT(8, HID_IOF_CONSTANT),
-    HID_RI_END_COLLECTION(0),
-#endif
-
-#ifdef SHARED_EP_ENABLE
-};
-#endif
+#endif // DIGITIZER_MODE_TOUCHPAD relocated decl
 
 #ifdef RAW_ENABLE
 const USB_Descriptor_HIDReport_Datatype_t PROGMEM RawReport[] = {


### PR DESCRIPTION
## Summary

In touchpad mode (`DIGITIZER_MODE = touchpad`) the stylus `DigitizerReport[]` block and the `DigitizerTouchpadReport[]` declaration both end up syntactically nested inside the still-open `SharedReport[]` initializer when `KEYBOARD_SHARED_EP` is enabled. The compiler reports:

```
tmk_core/protocol/usb_descriptor.c:316: error: expected expression before 'const'
tmk_core/protocol/usb_descriptor.c:1284: error: 'DigitizerTouchpadReport' undeclared
```

Touchpad mode deliberately does not define `DIGITIZER_SHARED_EP` (PTP requires a dedicated 64-byte endpoint, see `tmk_core/protocol.mk` line 82 comment), so it must not emit any top-level declarations between the `SharedReport` opening `{` and closing `};`.

This PR:

- Gates the stylus `DigitizerReport` block with `!defined(DIGITIZER_MODE_TOUCHPAD)` so it is skipped in touchpad mode.
- Moves the `DigitizerTouchpadReport[]` declaration to after `#ifdef SHARED_EP_ENABLE };`, so it lives at file scope. The `PTP_FINGER_COLLECTION` macro stays at its original location above, so it is still defined before the relocated use.

No behavior change for stylus mode or for builds without `SHARED_EP_ENABLE`.

## Reproduction

`keyboards/zsa/voyager` with `KEYBOARD_SHARED_EP = yes` + the `zsa/navigator_trackpad` community module declared in `keymap.json`. Without this patch the firmware fails to compile; with it the keyboard enumerates as a PTP touchpad and the Voyager Navigator trackpad works.

## Test plan

- [x] Builds for `zsa/voyager` with `zsa/navigator_trackpad` module (firmware25 branch).
- [x] Flashed to hardware, trackpad reports correctly as PTP touchpad.
- [ ] Verified no regression for `zsa/voyager:default` (no digitizer).
- [ ] Verified no regression for `zsa/voyager:oryx` (no digitizer).